### PR TITLE
Fix permission error external reply previews

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -402,7 +402,7 @@ console.log(chalk.red('Error en print.js'), e)
 }
 }
 }
-global.dfail = (type, m, conn) => { failureHandler(type, conn, m); };
+global.dfail = (type, m, conn) => failureHandler(type, conn, m);
 const file = global.__filename(import.meta.url, true);
 watchFile(file, async () => {
 unwatchFile(file);

--- a/lib/respuesta.js
+++ b/lib/respuesta.js
@@ -47,12 +47,29 @@ const iconos = [
 ];
 
 // Función para obtener una aleatoria
-const getRandomIcono = () => iconos[Math.floor(Math.random() * iconos.length)];
+const getRandomIcono = () => iconos[Math.floor(Math.random() * iconos.length)]
+  .replace('https://github.com/Dioneibi-rip/imagenes/blob/main/', 'https://raw.githubusercontent.com/Dioneibi-rip/imagenes/refs/heads/main/');
+const defaultSourceUrl = 'https://whatsapp.com/channel/0029Vag9VSI2ZjCocqa2lB1y';
+
+const getSourceUrl = () => globalThis.redes || defaultSourceUrl;
+
+const getRandomThumbnail = async (conn) => {
+  const thumbnailUrl = getRandomIcono();
+
+  try {
+    const file = await conn.getFile(thumbnailUrl);
+    if (file?.data && file?.mime?.startsWith('image/')) return { thumbnail: file.data };
+  } catch (error) {
+    console.error('Error descargando miniatura para externalAdReply:', error);
+  }
+
+  return {};
+};
 
 /**
  * Plugin centralizado para manejar todos los mensajes de error de permisos.
  */
-const handler = (type, conn, m, comando) => {
+const handler = async (type, conn, m, comando) => {
   const msg = {
   rowner: '「🌺」 *Gomenasai~! Esta función solo la puede usar mi creador celestial...* 🌌\n\n> *Dioneibi-sama.*',
   owner: '「🌸」 *¡Nyaa~! Solo mi creador y programadores pueden usar este comando~!* 💾💕',
@@ -67,6 +84,7 @@ const handler = (type, conn, m, comando) => {
   }[type];
 
   if (msg) {
+    const thumbnailInfo = await getRandomThumbnail(conn);
     const contextInfo = {
       mentionedJid: [m.sender],
       isForwarded: true,
@@ -79,8 +97,9 @@ const handler = (type, conn, m, comando) => {
       externalAdReply: {
         title: packname,
         body: 'I🎀 𓈒꒰ 𝐘𝐚𝐲~ 𝐇𝐨𝐥𝐚𝐚𝐚! (≧∇≦)/',
-        thumbnailUrl: getRandomIcono(), // ← aleatoria
-        sourceUrl: redes,
+        ...thumbnailInfo,
+        sourceUrl: getSourceUrl(),
+        mediaUrl: getSourceUrl(),
         mediaType: 1,
         renderLargerThumbnail: false
       }


### PR DESCRIPTION
### Motivation
- Los mensajes de error de permisos usaban `externalAdReply` con `thumbnailUrl` y `sourceUrl`, y esos previews solo eran visibles para el bot/WhatsApp Business; el comando `play` usa una miniatura en buffer y `mediaUrl` y funciona para todos, por lo que se buscó igualar ese comportamiento para que los errores sean visibles para todos.

### Description
- En `lib/respuesta.js` convertí el `handler` a `async` y añadí `getRandomThumbnail(conn)` que descarga la miniatura con `conn.getFile()` y devuelve un `thumbnail` en `Buffer` si es una imagen (validando `mime`).
- Normalicé URLs tipo `github blob` a `raw` para evitar HTML en vez de imagen y añadí un `defaultSourceUrl` y `getSourceUrl()` para un fallback estable; además se incluye `mediaUrl` junto a `sourceUrl` en `externalAdReply`.
- Reemplacé el uso de `thumbnailUrl` por el `thumbnail` en buffer obtenido y dejé un fallback seguro cuando la descarga falla.
- En `handler.js` actualicé `global.dfail` para retornar directamente la promesa del handler de errores, de modo que el flujo `async` se propague correctamente.

### Testing
- Ejecuté `node --check lib/respuesta.js` y `node --check handler.js`; ambas comprobaciones pasaron correctamente.
- Ejecuté un test modular con `node --input-type=module` que simula `conn.getFile()` y valida que `externalAdReply.thumbnail` sea enviado como `Buffer`, y ese test pasó.
- `npm test` falló por configuración del proyecto porque el script apunta a un archivo inexistente `test.js` (no es fallo del cambio de código). 
- `npm run test:baileys` falló igualmente porque apunta a `scripts/baileys-smoke.js` que no existe en el repositorio (no relacionado con estos cambios).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a014c3fe0ac832f89d4c44249983028)