### PR TITLE
Optimize plugin dispatch and subbot startup

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -7,6 +7,7 @@ import { unwatchFile, watchFile } from 'fs'
 import chalk from 'chalk'
 import fetch from 'node-fetch'
 import failureHandler from './lib/respuesta.js';
+import { getPluginRuntimeCache, getPrefixMatch, getCommandFromText, commandMatches } from './lib/pluginRuntimeCache.js'
 const { proto } = (await import('@whiskeysockets/baileys')).default
 const isNumber = x => typeof x === 'number' && !isNaN(x)
 const delay = ms => isNumber(ms) && new Promise(resolve => setTimeout(function () {
@@ -226,50 +227,55 @@ if (idx !== -1) queque.splice(idx, 1)
 }, time)
 }
 m.exp += Math.ceil(Math.random() * 10)
-let usedPrefix
 const ___dirname = path.join(path.dirname(fileURLToPath(import.meta.url)), './plugins')
-for (let name in global.plugins) {
-let plugin = global.plugins[name]
-if (!plugin) continue
-if (plugin.disabled) continue
+const runtime = getPluginRuntimeCache(global.plugins)
+const basePrefix = this.prefix ? this.prefix : global.prefix
+const skippedPlugins = new Set()
+
+for (const { name, plugin } of runtime.all) {
+if (!plugin || plugin.disabled) continue
 const __filename = join(___dirname, name)
-if (typeof plugin.all === 'function') {
 try {
 await plugin.all.call(this, m, { chatUpdate, __dirname: ___dirname, __filename })
 } catch (e) { console.error(e) }
 }
+
+for (const { name, plugin } of runtime.before) {
+if (!plugin || plugin.disabled) continue
 if (!opts['restrict'] && plugin.tags && plugin.tags.includes('admin')) continue
-const str2Regex = str => str.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
-let _prefix = plugin.customPrefix ? plugin.customPrefix : this.prefix ? this.prefix : global.prefix
-let match = (_prefix instanceof RegExp ? [[_prefix.exec(m.text), _prefix]] :
-Array.isArray(_prefix) ? _prefix.map(p => {
-let re = p instanceof RegExp ? p : new RegExp(str2Regex(p))
-return [re.exec(m.text), re]
-}) :
-typeof _prefix === 'string' ? [[new RegExp(str2Regex(_prefix)).exec(m.text), new RegExp(str2Regex(_prefix))]] : [[[], new RegExp]]
-).find(p => p[1])
-if (typeof plugin.before === 'function') {
+const __filename = join(___dirname, name)
+const _prefix = plugin.customPrefix ? plugin.customPrefix : basePrefix
+const match = getPrefixMatch(_prefix, m.text)
+try {
 if (await plugin.before.call(this, m, {
 match, conn: this, participants, groupMetadata, user: userGroup, bot: botGroup, isROwner, isOwner, isRAdmin, isAdmin, isBotAdmin, isPrems, chatUpdate, __dirname: ___dirname, __filename
-})) continue
+})) skippedPlugins.add(name)
+} catch (e) { console.error(e) }
 }
-if (typeof plugin !== 'function') continue
-if (!(match && match[0])) continue
-if ((usedPrefix = (match[0] || '')[0])) {
-if (['>', '=>', '$'].includes(usedPrefix)) continue
-let noPrefix = m.text.replace(usedPrefix, '')
-let [command, ...args] = noPrefix.trim().split` `.filter(v => v)
-args = args || []
-let _args = noPrefix.trim().split` `.slice(1)
-let text = _args.join` `
-command = (command || '').toLowerCase()
-if (!/^[a-z0-9][\w-]*$/i.test(command)) continue
+
+const baseMatch = getPrefixMatch(basePrefix, m.text)
+const parsedCommand = getCommandFromText(m.text, baseMatch)
+if (parsedCommand && (m.id && (m.id.startsWith('NJX-') || (m.id.startsWith('BAE5') && m.id.length === 16) || (m.id.startsWith('B24E') && m.id.length === 20)))) return
+const candidateMap = new Map()
+if (parsedCommand) {
+for (const entry of runtime.commandMap.get(parsedCommand.command) || []) candidateMap.set(entry.name, entry)
+}
+for (const entry of runtime.dynamicCommands) {
+if (parsedCommand || entry.plugin?.customPrefix) candidateMap.set(entry.name, entry)
+}
+const commandCandidates = [...candidateMap.values()].sort((a, b) => a.order - b.order)
+for (const { name, plugin } of commandCandidates) {
+if (!plugin || plugin.disabled || skippedPlugins.has(name)) continue
+if (!opts['restrict'] && plugin.tags && plugin.tags.includes('admin')) continue
+const __filename = join(___dirname, name)
+const _prefix = plugin.customPrefix ? plugin.customPrefix : basePrefix
+const match = plugin.customPrefix ? getPrefixMatch(_prefix, m.text) : baseMatch
+const commandInfo = plugin.customPrefix ? getCommandFromText(m.text, match) : parsedCommand
+if (!commandInfo) continue
+let { usedPrefix, noPrefix, command, args, _args, text } = commandInfo
 let fail = plugin.fail || global.dfail
-let isAccept = plugin.command instanceof RegExp ? plugin.command.test(command) :
-Array.isArray(plugin.command) ? plugin.command.some(cmd => cmd instanceof RegExp ? cmd.test(command) : cmd === command) :
-typeof plugin.command === 'string' ? plugin.command === command : false
+let isAccept = commandMatches(plugin.command, command)
 global.comando = command
-if ((m.id && (m.id.startsWith('NJX-') || (m.id.startsWith('BAE5') && m.id.length === 16) || (m.id.startsWith('B24E') && m.id.length === 20)))) return
 if (!isAccept) continue
 const disabledCommands = global.db.data.settings[this.user.jid]?.disabledCommands || []
 if (!isROwner && !isOwner && disabledCommands.includes(command)) {
@@ -350,7 +356,6 @@ await plugin.after.call(this, m, extra)
 if (m.coin) this.reply(m.chat, `❮✦❯ Utilizaste ${+m.coin} ${m.moneda}`, m)
 }
 break
-}
 }
 } catch (e) {
 console.error(e)

--- a/index.js
+++ b/index.js
@@ -251,17 +251,23 @@ console.log(chalk.bold.cyan(`✨ Cargando sub-Bots...`))
 const readRutaJadiBot = readdirSync(global.rutaJadiBot)
 if (readRutaJadiBot.length > 0) {
 const creds = 'creds.json'
-for (const gjbts of readRutaJadiBot) {
-const botPath = join(global.rutaJadiBot, gjbts)
-const readBotPath = readdirSync(botPath)
-if (readBotPath.includes(creds)) { 
+const subBotPaths = readRutaJadiBot
+.map(gjbts => join(global.rutaJadiBot, gjbts))
+.filter(botPath => {
+try { return statSync(botPath).isDirectory() && readdirSync(botPath).includes(creds) }
+catch { return false }
+})
+const batchSize = Math.max(1, Number(global.subBotLoadBatch || 3))
+for (let i = 0; i < subBotPaths.length; i += batchSize) {
+const batch = subBotPaths.slice(i, i + batchSize)
+await Promise.all(batch.map(async (botPath) => {
 try {
-RubyJadiBot({ pathRubyJadiBot: botPath, m: null, conn, args: '', usedPrefix: '/', command: 'serbot' }) 
-await new Promise(resolve => setTimeout(resolve, 2500)); 
-} catch(e) { 
-console.log(chalk.red('Error cargando subbot:'), e) 
+await RubyJadiBot({ pathRubyJadiBot: botPath, m: null, conn, args: '', usedPrefix: '/', command: 'serbot' })
+} catch(e) {
+console.log(chalk.red('Error cargando subbot:'), e)
 }
-}
+}))
+if (i + batchSize < subBotPaths.length) await new Promise(resolve => setTimeout(resolve, 500))
 }
 }
 }

--- a/lib/pluginRuntimeCache.js
+++ b/lib/pluginRuntimeCache.js
@@ -1,0 +1,106 @@
+const REGEX_SPECIAL_CHARS = /[|\\{}()[\]^$+*?.]/g
+
+let cachedPluginRefs = new Map()
+let cachedPluginCount = -1
+let cachedRuntime = null
+
+const escapeRegex = (str) => str.replace(REGEX_SPECIAL_CHARS, '\\$&')
+
+function asArray(value) {
+  if (!value) return []
+  return Array.isArray(value) ? value : [value]
+}
+
+function isCacheValid(entries) {
+  if (!cachedRuntime || entries.length !== cachedPluginCount) return false
+  for (const [name, plugin] of entries) {
+    if (cachedPluginRefs.get(name) !== plugin) return false
+  }
+  return true
+}
+
+function hasNonStringCommand(plugin) {
+  return asArray(plugin?.command).some((cmd) => typeof cmd !== 'string')
+}
+
+export function getPluginRuntimeCache(plugins = {}) {
+  const entries = Object.entries(plugins)
+  if (isCacheValid(entries)) return cachedRuntime
+
+  const all = []
+  const before = []
+  const commandMap = new Map()
+  const dynamicCommands = []
+  const refs = new Map()
+
+  entries.forEach(([name, plugin], order) => {
+    refs.set(name, plugin)
+    if (!plugin) return
+
+    const entry = { name, plugin, order }
+    if (typeof plugin.all === 'function') all.push(entry)
+    if (typeof plugin.before === 'function') before.push(entry)
+
+    if (typeof plugin === 'function' && plugin.command) {
+      const commands = asArray(plugin.command)
+      const usesDynamicPrefix = Boolean(plugin.customPrefix)
+      let hasStringCommand = false
+
+      for (const command of commands) {
+        if (typeof command !== 'string') continue
+        hasStringCommand = true
+        const key = command.toLowerCase()
+        const list = commandMap.get(key) || []
+        list.push(entry)
+        commandMap.set(key, list)
+      }
+
+      if (usesDynamicPrefix || hasNonStringCommand(plugin) || !hasStringCommand) {
+        dynamicCommands.push(entry)
+      }
+    }
+  })
+
+  cachedPluginRefs = refs
+  cachedPluginCount = entries.length
+  cachedRuntime = { all, before, commandMap, dynamicCommands }
+  return cachedRuntime
+}
+
+export function getPrefixMatches(prefix, text = '') {
+  if (prefix instanceof RegExp) return [[prefix.exec(text), prefix]]
+  if (Array.isArray(prefix)) {
+    return prefix.map((item) => {
+      const regex = item instanceof RegExp ? item : new RegExp(escapeRegex(String(item)))
+      return [regex.exec(text), regex]
+    })
+  }
+  if (typeof prefix === 'string') {
+    const regex = new RegExp(escapeRegex(prefix))
+    return [[regex.exec(text), regex]]
+  }
+  return [[[], new RegExp()]]
+}
+
+export function getPrefixMatch(prefix, text = '') {
+  return getPrefixMatches(prefix, text).find((item) => item[1])
+}
+
+export function getCommandFromText(text = '', prefixMatch) {
+  const usedPrefix = (prefixMatch?.[0] || '')[0]
+  if (!usedPrefix || ['>', '=>', '$'].includes(usedPrefix)) return null
+  const noPrefix = text.replace(usedPrefix, '')
+  const [rawCommand, ...args] = noPrefix.trim().split` `.filter(Boolean)
+  const command = (rawCommand || '').toLowerCase()
+  if (!command || !/^[a-z0-9][\w-]*$/i.test(command)) return null
+  return { usedPrefix, noPrefix, command, args, _args: noPrefix.trim().split` `.slice(1), text: args.join` ` }
+}
+
+export function commandMatches(commandConfig, command) {
+  if (!command) return false
+  if (commandConfig instanceof RegExp) return commandConfig.test(command)
+  if (Array.isArray(commandConfig)) {
+    return commandConfig.some((cmd) => cmd instanceof RegExp ? cmd.test(command) : cmd === command)
+  }
+  return typeof commandConfig === 'string' ? commandConfig === command : false
+}

--- a/lib/simple.js
+++ b/lib/simple.js
@@ -1804,10 +1804,17 @@ return conn.sendMessage(jid, { poll: { name, values, selectableCount }})
             }
         },
         insertAllGroup: {
-            async value() {
-                const groups = await conn.groupFetchAllParticipating().catch(_ => null) || {}
-                for (const group in groups) conn.chats[group] = { ...(conn.chats[group] || {}), id: group, subject: groups[group].subject, isChats: true, metadata: groups[group] }
-                return conn.chats
+            async value(force = false) {
+                const now = Date.now()
+                if (!force && conn._insertAllGroupPromise) return conn._insertAllGroupPromise
+                if (!force && conn._lastInsertAllGroup && now - conn._lastInsertAllGroup < 60_000) return conn.chats
+                conn._lastInsertAllGroup = now
+                conn._insertAllGroupPromise = (async () => {
+                    const groups = await conn.groupFetchAllParticipating().catch(_ => null) || {}
+                    for (const group in groups) conn.chats[group] = { ...(conn.chats[group] || {}), id: group, subject: groups[group].subject, isChats: true, metadata: groups[group] }
+                    return conn.chats
+                })().finally(() => { conn._insertAllGroupPromise = null })
+                return conn._insertAllGroupPromise
             },
         },
         pushMessage: {


### PR DESCRIPTION
### Motivation
- Reducir la sobrecarga por recorrido completo de plugins en cada mensaje y evitar llamadas costosas repetidas al iniciar múltiples sub-bots o consultar metadata de grupos.
- Mejorar latencia al despachar comandos y procesar hooks globales (`all`/`before`) sin iterar innecesariamente 400+ plugins por mensaje.

### Description
- Añadido `lib/pluginRuntimeCache.js` para construir y cachear un runtime de plugins con listas separadas de `all`, `before`, `commandMap` y `dynamicCommands` para búsquedas rápidas.
- Refactor en `handler.js` para usar el cache runtime y ejecutar primero sólo los hooks globales necesarios, luego resolver únicamente candidatos de comando que coincidan, manteniendo soporte para `customPrefix` y comandos dinámicos.
- Cambiado el arranque de sub-bots en `index.js` para descubrir rutas válidas y arrancarlos en lotes (configurable con `global.subBotLoadBatch`) en paralelo con pausas cortas entre lotes en vez de iniciar secuencialmente con retrasos largos.
- Añadido throttling/in-flight caching a `insertAllGroup` en `lib/simple.js` para impedir llamadas repetidas a `groupFetchAllParticipating()` durante ráfagas y reducir carga de red/IO.

### Testing
- Ejecutado chequeo de sintaxis: `node --check handler.js && node --check index.js && node --check lib/simple.js && node --check lib/pluginRuntimeCache.js` (OK).
- Ejecutado test de humo del cache runtime con un pequeño script `node --input-type=module - <<'NODE' ... NODE` para validar parseo de prefijos/comandos y matching (OK).
- `npm run eslint` no completó porque el repositorio carece de `eslint.config.(js|mjs|cjs)` requerido por ESLint 9+, por lo que fue bloqueado (no falló el código modificado pero la comprobación está incompleta).
- `npm test -- --help` no pudo ejecutarse porque `package.json` refiere a `test.js` que no existe en el repo (comprobación de test no disponible).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a015e368cf48329ae7b06f5d91a4eb5)