### PR TITLE
Mejorar estilo y layout del sticker `brat`

### DIFF
--- a/plugins/sticker-brat.js
+++ b/plugins/sticker-brat.js
@@ -5,8 +5,12 @@ import { sticker } from '../lib/sticker.js'
 const FINAL_SIZE = 512
 const WORK_SIZE = 1024
 const MAX_TEXT_LENGTH = 280
-const BG_COLOR = '#F2F2F2'
-const TOKEN_GAP = 22
+const BG_COLOR = '#FFFFFF'
+const SAFE_MARGIN = 42
+const MIN_BOTTOM_MARGIN = 32
+const EMOJI_SCALE = 1.08
+const BRAT_BLUR = 3
+const TEXT_DENSITY_LIMIT = WORK_SIZE - SAFE_MARGIN - MIN_BOTTOM_MARGIN
 
 const FONT_CANDIDATES = [
   Jimp.FONT_SANS_128_BLACK,
@@ -65,10 +69,12 @@ async function getEmojiImage(emoji = '') {
 }
 
 async function buildToken(font, raw = '') {
+  const lineHeight = Jimp.measureTextHeight(font, 'Ay', WORK_SIZE)
+
   if (isEmojiToken(raw)) {
     const emojiImg = await getEmojiImage(raw)
     if (emojiImg) {
-      const size = Math.max(66, Math.min(140, Jimp.measureTextHeight(font, 'Ay', WORK_SIZE) + 6))
+      const size = Math.round(Math.max(76, Math.min(152, lineHeight * EMOJI_SCALE)))
       return {
         type: 'emoji',
         text: raw,
@@ -83,39 +89,51 @@ async function buildToken(font, raw = '') {
     type: 'text',
     text: raw,
     width: Jimp.measureText(font, raw),
-    height: Jimp.measureTextHeight(font, 'Ay', WORK_SIZE),
+    height: lineHeight,
   }
 }
 
-function buildRows(tokens = []) {
+function getColumnCount(tokens = [], fontHeight = 0) {
+  const textTokens = tokens.filter((token) => token.type === 'text')
+  const shortTokens = textTokens.filter((token) => token.width <= fontHeight * 3.35).length
+  const shortRatio = textTokens.length ? shortTokens / textTokens.length : 0
+
+  if (tokens.length >= 9 && shortRatio >= 0.72) return 3
+  if (tokens.length >= 7 && shortRatio >= 0.86) return 3
+  return 2
+}
+
+function getColumnAnchors(columnCount = 2) {
+  if (columnCount === 3) return [54, 395, 746]
+  return [64, 586]
+}
+
+function getLineHeight(fontHeight = 0, rowsCount = 1) {
+  const base = Math.round(fontHeight * 1.18)
+  if (rowsCount <= 3) return Math.max(164, base)
+  if (rowsCount <= 5) return Math.max(136, base)
+  return Math.max(108, base)
+}
+
+function buildRows(tokens = [], columnCount = 2) {
   const rows = []
-  let current = { left: null, right: null }
 
-  for (let i = 0; i < tokens.length; i++) {
-    const tok = tokens[i]
-
-    if (i > 0 && i % 8 === 5 && !current.left && !current.right) {
-      rows.push({ center: tok })
-      continue
-    }
-
-    if (!current.left) {
-      current.left = tok
-      continue
-    }
-
-    if (!current.right) {
-      current.right = tok
-      rows.push(current)
-      current = { left: null, right: null }
-    }
+  for (let i = 0; i < tokens.length; i += columnCount) {
+    rows.push(tokens.slice(i, i + columnCount))
   }
 
-  if (current.left || current.right) rows.push(current)
   return rows
 }
 
+function scoreLayout(rows = [], lineHeight = 0) {
+  const filledCells = rows.reduce((total, row) => total + row.length, 0)
+  const lastRowPenalty = rows.length > 1 && rows[rows.length - 1].length === 1 ? 0.45 : 0
+  return rows.length * lineHeight + filledCells + lastRowPenalty
+}
+
 async function chooseLayout(rawTokens = []) {
+  let bestLayout = null
+
   for (const fontPath of FONT_CANDIDATES) {
     const font = await Jimp.loadFont(fontPath)
     const tokens = []
@@ -125,25 +143,47 @@ async function chooseLayout(rawTokens = []) {
       tokens.push(await buildToken(font, raw))
     }
 
-    const rows = buildRows(tokens)
-    const lineHeight = Math.max(92, Jimp.measureTextHeight(font, 'Ay', WORK_SIZE) + 28)
-    const contentHeight = rows.length * lineHeight
+    const fontHeight = Jimp.measureTextHeight(font, 'Ay', WORK_SIZE)
+    const preferredColumns = getColumnCount(tokens, fontHeight)
+    const columnOptions = preferredColumns === 3 ? [3, 2] : [2, 3]
 
-    if (contentHeight <= WORK_SIZE - 120) {
-      return { font, rows, lineHeight }
+    for (const columnCount of columnOptions) {
+      const rows = buildRows(tokens, columnCount)
+      const lineHeight = getLineHeight(fontHeight, rows.length)
+      const contentHeight = rows.length * lineHeight
+      const layout = {
+        font,
+        rows,
+        lineHeight,
+        columnAnchors: getColumnAnchors(columnCount),
+        score: scoreLayout(rows, lineHeight),
+      }
+
+      if (contentHeight <= TEXT_DENSITY_LIMIT) return layout
+      if (!bestLayout || layout.score < bestLayout.score) bestLayout = layout
     }
   }
 
-  const fallbackFont = await Jimp.loadFont(Jimp.FONT_SANS_32_BLACK)
-  const fallbackTokens = []
-  for (const raw of rawTokens) {
-    // eslint-disable-next-line no-await-in-loop
-    fallbackTokens.push(await buildToken(fallbackFont, raw))
+  if (!bestLayout) {
+    const fallbackFont = await Jimp.loadFont(Jimp.FONT_SANS_32_BLACK)
+    const fallbackTokens = []
+    for (const raw of rawTokens) {
+      // eslint-disable-next-line no-await-in-loop
+      fallbackTokens.push(await buildToken(fallbackFont, raw))
+    }
+
+    const rows = buildRows(fallbackTokens, 2).slice(0, 18)
+    bestLayout = {
+      font: fallbackFont,
+      rows,
+      lineHeight: Math.max(72, Jimp.measureTextHeight(fallbackFont, 'Ay', WORK_SIZE) + 18),
+      columnAnchors: getColumnAnchors(2),
+    }
   }
+
   return {
-    font: fallbackFont,
-    rows: buildRows(fallbackTokens).slice(0, 18),
-    lineHeight: Math.max(72, Jimp.measureTextHeight(fallbackFont, 'Ay', WORK_SIZE) + 18),
+    ...bestLayout,
+    rows: bestLayout.rows.slice(0, Math.max(1, Math.floor(TEXT_DENSITY_LIMIT / bestLayout.lineHeight))),
   }
 }
 
@@ -151,11 +191,17 @@ function drawToken(layer, font, token, x, y) {
   if (!token) return
 
   if (token.type === 'emoji' && token.image) {
-    layer.composite(token.image, x, y + 2)
+    layer.composite(token.image, Math.round(x), Math.round(y + 4))
     return
   }
 
-  layer.print(font, x, y, token.text)
+  layer.print(font, Math.round(x), Math.round(y), token.text)
+}
+
+function getRowOffset(row = [], rowIndex = 0, rowsCount = 1) {
+  if (row.length === 1 && rowsCount <= 2) return 0.38
+  if (row.length === 1 && rowIndex % 3 === 1) return 0.16
+  return 0
 }
 
 async function renderBratImage(text = '') {
@@ -165,67 +211,33 @@ async function renderBratImage(text = '') {
   const rawTokens = splitWithEmoji(cleanText)
   if (!rawTokens.length) throw new Error('No se encontraron tokens para renderizar.')
 
-  const { font, rows, lineHeight } = await chooseLayout(rawTokens)
+  const { font, rows, lineHeight, columnAnchors } = await chooseLayout(rawTokens)
 
   const image = new Jimp(WORK_SIZE, WORK_SIZE, BG_COLOR)
-  const shadow = new Jimp(WORK_SIZE, WORK_SIZE, 0x00000000)
   const textLayer = new Jimp(WORK_SIZE, WORK_SIZE, 0x00000000)
 
-  const leftX = 64
-  const rightX = 586
-  const centerX = 190
-  const centerW = 640
-
   const contentHeight = rows.length * lineHeight
-  let y = Math.max(56, Math.floor((WORK_SIZE - contentHeight) / 2))
+  let y = Math.max(SAFE_MARGIN, Math.floor((WORK_SIZE - contentHeight) / 2) - 10)
 
-  for (const row of rows) {
-    if (row.center) {
-      const token = row.center
-      if (token.type === 'emoji' && token.image) {
-        const cx = centerX + Math.floor((centerW - token.width) / 2)
-        drawToken(shadow, font, token, cx + 6, y + 6)
-        drawToken(textLayer, font, token, cx, y)
-      } else {
-        shadow.print(
-          font,
-          centerX + 6,
-          y + 6,
-          { text: token.text, alignmentX: Jimp.HORIZONTAL_ALIGN_CENTER, alignmentY: Jimp.VERTICAL_ALIGN_TOP },
-          centerW,
-          lineHeight,
-        )
-        textLayer.print(
-          font,
-          centerX,
-          y,
-          { text: token.text, alignmentX: Jimp.HORIZONTAL_ALIGN_CENTER, alignmentY: Jimp.VERTICAL_ALIGN_TOP },
-          centerW,
-          lineHeight,
-        )
-      }
-    } else {
-      if (row.left) {
-        drawToken(shadow, font, row.left, leftX + 6, y + 6)
-        drawToken(textLayer, font, row.left, leftX, y)
-      }
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const row = rows[rowIndex]
+    const rowOffset = Math.round(getRowOffset(row, rowIndex, rows.length) * WORK_SIZE)
 
-      if (row.right) {
-        const rightTokenX = rightX + (row.right.type === 'text' ? TOKEN_GAP : 0)
-        drawToken(shadow, font, row.right, rightTokenX + 6, y + 6)
-        drawToken(textLayer, font, row.right, rightTokenX, y)
-      }
+    for (let columnIndex = 0; columnIndex < row.length; columnIndex++) {
+      const token = row[columnIndex]
+      const anchor = columnAnchors[columnIndex] ?? columnAnchors[0]
+      const x = Math.min(WORK_SIZE - token.width - SAFE_MARGIN, anchor + rowOffset)
+      const tokenY = y + (token.type === 'emoji' ? Math.max(0, Math.round((lineHeight - token.height) * 0.24)) : 0)
+      drawToken(textLayer, font, token, x, tokenY)
     }
 
     y += lineHeight
   }
 
-  shadow.blur(3).opacity(0.24)
-  textLayer.blur(1)
-
-  image.composite(shadow, 0, 0)
+  textLayer.blur(BRAT_BLUR)
   image.composite(textLayer, 0, 0)
   image.resize(FINAL_SIZE, FINAL_SIZE, Jimp.RESIZE_BILINEAR)
+  image.blur(1)
 
   return image.getBufferAsync(Jimp.MIME_PNG)
 }


### PR DESCRIPTION
### Motivation
- Ajustar el render del sticker `brat` para que se parezca más a las imágenes de referencia con aspecto más "brat/meme": fondo blanco, texto más suelto y efecto borroso.
- Hacer el layout más adaptable a diferentes longitudes de texto y emojis para evitar composiciones rígidas y mejorar la apariencia en varias entradas.

### Description
- Reescribí `plugins/sticker-brat.js` para usar un fondo blanco (`BG_COLOR = '#FFFFFF'`), márgenes seguros (`SAFE_MARGIN`) y un límite de densidad de texto (`TEXT_DENSITY_LIMIT`).
- Reemplacé la lógica de filas fija por un layout adaptable de 2/3 columnas con funciones nuevas: `getColumnCount`, `getColumnAnchors`, `getLineHeight`, `buildRows`, `scoreLayout` y `getRowOffset` para distribución más orgánica.
- Mejoré el tratamiento de emojis escalando y posicionando según la altura de línea con `EMOJI_SCALE`, y ajusté el renderizado para redondear coordenadas y suavizar el resultado (`BRAT_BLUR`, `image.blur(1)`).
- Mantengo la interfaz existente: `renderBratImage`, `makeBratSticker` y el handler del comando `brat` siguen funcionando con `sticker()` de `lib/sticker.js`.

### Testing
- `node --check plugins/sticker-brat.js` — verificado y sin errores.
- `node --input-type=module -e "await import('./plugins/sticker-brat.js'); console.log('import ok')"` — import OK.
- Ejecución de un mock del handler con texto de ejemplo — generó correctamente un buffer `brat.webp` (sticker creado).
- `npx eslint plugins/sticker-brat.js` — no se pudo completar por la configuración del entorno (ESLint 10 requiere `eslint.config.*` y el repo no tiene configuración plana), por lo que no se reportaron errores de lint aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a047567c6fc83298257872b2e065390)