### PR TITLE
Remove externalAdReply metadata from bot responses

### DIFF
--- a/lib/respuesta.js
+++ b/lib/respuesta.js
@@ -93,17 +93,7 @@ const handler = async (type, conn, m, comando) => {
         newsletterJid,
         newsletterName,
         serverMessageId: -1
-      },
-      externalAdReply: {
-        title: packname,
-        body: 'I🎀 𓈒꒰ 𝐘𝐚𝐲~ 𝐇𝐨𝐥𝐚𝐚𝐚! (≧∇≦)/',
-        ...thumbnailInfo,
-        sourceUrl: getSourceUrl(),
-        mediaUrl: getSourceUrl(),
-        mediaType: 1,
-        renderLargerThumbnail: false
-      }
-    };
+      }};
 
     return conn.reply(m.chat, msg, m, { contextInfo }).then(_ => m.react('✖️'));
   }

--- a/lib/simple.js
+++ b/lib/simple.js
@@ -165,7 +165,7 @@ sendListB: {
         sendBot: {
     async value(jid, text = '', buffer, title, body, url, quoted, options) {
     if (buffer) try { (type = await conn.getFile(buffer), buffer = type.data) } catch (e) { buffer = buffer }
-        let prep = generateWAMessageFromContent(jid, { extendedTextMessage: { text: text, contextInfo: { externalAdReply: { title: title, body: body, thumbnail: buffer, sourceUrl: url }, mentionedJid: await conn.parseMention(text) }}}, { quoted: quoted })
+        let prep = generateWAMessageFromContent(jid, { extendedTextMessage: { text: text, contextInfo: {  mentionedJid: await conn.parseMention(text) }}}, { quoted: quoted })
     return conn.relayMessage(jid, prep.message, { messageId: prep.key.id })
 }
 },
@@ -180,9 +180,7 @@ sendListB: {
            extendedTextMessage: {
              text: text,
            contextInfo: {
-           externalAdReply: {
-             showAdAttribution: true
-           }, mentionedJid: conn.parseMention(text) }}}}}, {})}
+            mentionedJid: conn.parseMention(text) }}}}}, {})}
       },        
         getFile: {
             /**
@@ -266,8 +264,7 @@ END:VCARD
                     contacts: {
                         ...options,
                         displayName: (contacts.length >= 2 ? `${contacts.length} kontak` : contacts[0].displayName) || null,
-                        contacts,
-                    }
+                        contacts}
                 }, { quoted, ...options })
             },
             enumerable: true
@@ -590,23 +587,10 @@ reply: {
                         async value(jid, title, body, text = '', thumbnailUrl, thumbnail, sourceUrl, quoted, LargerThumbnail = true) {
                                 return conn.sendMessage(jid, { ...{
                                         contextInfo: {
-                                                mentionedJid: await conn.parseMention(text),
-                                                externalAdReply: {
-                                                        title: title,
-                                                        body: body,
-                                                        mediaType: 1,
-                                                        previewType: 0,
-                                                        renderLargerThumbnail: LargerThumbnail,
-                                                        thumbnailUrl: thumbnailUrl,
-                                                        thumbnail: thumbnailUrl,
-                                                        sourceUrl: sourceUrl
-                                                },
-                                        },
-                                }, text }, { quoted })
+                                                mentionedJid: await conn.parseMention(text)}}, text }, { quoted })
                         },
                         enumerable: true,
-                        writable: true,
-                },
+                        writable: true},
 
 /**
      * send Button Vid
@@ -727,8 +711,7 @@ sendButtonLoc: {
         let buttons = [
         { buttonId: id1, buttonText: { displayText: button1 }, type: 1 },
         { buttonId: id2, buttonText: { displayText: button2 }, type: 1 },
-        { buttonId: id3, buttonText: { displayText: button3 }, type: 1 },
-        ]
+        { buttonId: id3, buttonText: { displayText: button3 }, type: 1 }]
         const buttonMessage = {
             video: file,
             fileLength: 800000000000000,
@@ -886,8 +869,7 @@ sendGroupV4Invite: {
           buttonParamsJson: JSON.stringify({
             display_text: btn[0],
             id: btn[1]
-          }),
-        }));
+          })}));
         dynamicButtons.push(
           (copy && (typeof copy === 'string' || typeof copy === 'number')) ? {
             name: 'cta_copy',
@@ -934,20 +916,13 @@ sendGroupV4Invite: {
           ...Object.assign({
             mentions: typeof text === 'string' ? conn.parseMention(text || '@0') : [],
             contextInfo: {
-              mentionedJid: typeof text === 'string' ? conn.parseMention(text || '@0') : [],
-            }
+              mentionedJid: typeof text === 'string' ? conn.parseMention(text || '@0') : []}
           }, {
             ...(options || {}),
             ...(conn.temareply?.contextInfo && {
               contextInfo: {
                 ...(options?.contextInfo || {}),
-                ...conn.temareply?.contextInfo,
-                externalAdReply: {
-                  ...(options?.contextInfo?.externalAdReply || {}),
-                  ...conn.temareply?.contextInfo?.externalAdReply,
-                },
-              },
-            })
+                ...conn.temareply?.contextInfo}})
           })
         };
         const messageContent = proto.Message.fromObject({
@@ -1041,8 +1016,7 @@ sendGroupV4Invite: {
               buttonParamsJson: JSON.stringify({
                 display_text: btn[0],
                 id: btn[1]
-              }),
-            }));
+              })}));
             copy = Array.isArray(copy) ? copy : [copy]
             copy.map(copy => {
                 dynamicButtons.push({
@@ -1095,20 +1069,13 @@ sendGroupV4Invite: {
               ...Object.assign({
                 mentions: typeof text === 'string' ? conn.parseMention(text || '@0') : [],
                 contextInfo: {
-                  mentionedJid: typeof text === 'string' ? conn.parseMention(text || '@0') : [],
-                }
+                  mentionedJid: typeof text === 'string' ? conn.parseMention(text || '@0') : []}
               }, {
                 ...(options || {}),
                 ...(conn.temareply?.contextInfo && {
                   contextInfo: {
                     ...(options?.contextInfo || {}),
-                    ...conn.temareply?.contextInfo,
-                    externalAdReply: {
-                      ...(options?.contextInfo?.externalAdReply || {}),
-                      ...conn.temareply?.contextInfo?.externalAdReply,
-                    },
-                  },
-                })
+                    ...conn.temareply?.contextInfo}})
               })
             };
           }));
@@ -1125,25 +1092,17 @@ sendGroupV4Invite: {
               hasMediaAttachment: false
             }),
             carouselMessage: proto.Message.InteractiveMessage.CarouselMessage.fromObject({
-              cards,
-            }),
+              cards}),
             ...Object.assign({
               mentions: typeof text === 'string' ? conn.parseMention(text || '@0') : [],
               contextInfo: {
-                mentionedJid: typeof text === 'string' ? conn.parseMention(text || '@0') : [],
-              }
+                mentionedJid: typeof text === 'string' ? conn.parseMention(text || '@0') : []}
             }, {
               ...(options || {}),
               ...(conn.temareply?.contextInfo && {
                 contextInfo: {
                   ...(options?.contextInfo || {}),
-                  ...conn.temareply?.contextInfo,
-                  externalAdReply: {
-                    ...(options?.contextInfo?.externalAdReply || {}),
-                    ...conn.temareply?.contextInfo?.externalAdReply,
-                  },
-                },
-              })
+                  ...conn.temareply?.contextInfo}})
             })
           });
           const messageContent = proto.Message.fromObject({
@@ -1273,8 +1232,7 @@ sendButton: {
             buttonParamsJson: JSON.stringify({
                 display_text: btn[0],
                 id: btn[1]
-            }),
-        }));
+            })}));
 
 
         if (copy && (typeof copy === 'string' || typeof copy === 'number')) {
@@ -1815,8 +1773,7 @@ return conn.sendMessage(jid, { poll: { name, values, selectableCount }})
                     return conn.chats
                 })().finally(() => { conn._insertAllGroupPromise = null })
                 return conn._insertAllGroupPromise
-            },
-        },
+            }},
         pushMessage: {
             /**
              * pushMessage
@@ -1863,8 +1820,7 @@ return conn.sendMessage(jid, { poll: { name, values, selectableCount }})
                                         remoteJid,
                                         fromMe: areJidsSameUser(conn.user.jid, remoteJid),
                                         id: context.stanzaId,
-                                        participant,
-                                    },
+                                        participant},
                                     message: JSON.parse(JSON.stringify(quoted)),
                                     ...(isGroup ? { participant } : {})
                                 }
@@ -1949,8 +1905,7 @@ return conn.sendMessage(jid, { poll: { name, values, selectableCount }})
                         attrs: {
                             to: S_WHATSAPP_NET,
                             type: 'set',
-                            xmlns: 'status',
-                        },
+                            xmlns: 'status'},
                         content: [
                             {
                                 tag: 'status',
@@ -2022,8 +1977,7 @@ export function serialize() {
     isBaileys: {
     get() {
     return (this?.fromMe || areJidsSameUser(this.conn?.user.id, this.sender)) && this.id.startsWith('3EB0') && (this.id.length === 20 || this.id.length === 22 || this.id.length === 12) || false
-        },
-    },
+        }},
         chat: {
             get() {
                 const senderKeyDistributionMessage = this.message?.senderKeyDistributionMessage?.groupId
@@ -2084,8 +2038,7 @@ export function serialize() {
                 if (!(message = this.mediaMessage)) return null
                 return Object.keys(message)[0]
             },
-            enumerable: true,
-        },
+            enumerable: true},
         quoted: {
             get() {
                 /**
@@ -2121,8 +2074,7 @@ export function serialize() {
                             if (!(message = this.mediaMessage)) return null
                             return Object.keys(message)[0]
                         },
-                        enumerable: true,
-                    },
+                        enumerable: true},
                     id: {
                         get() {
                             return contextInfo.stanzaId
@@ -2151,8 +2103,7 @@ export function serialize() {
                         get() {
                             return areJidsSameUser(this.sender, self.conn?.user.jid)
                         },
-                        enumerable: true,
-                    },
+                        enumerable: true},
                     text: {
                         get() {
                             return text || this.caption || this.contentText || this.selectedDisplayText || ''
@@ -2197,8 +2148,7 @@ export function serialize() {
                             return self.conn?.downloadM(this.mediaMessage[mtype], mtype.replace(/message/i, ''), saveToFile)
                         },
                         enumerable: true,
-                        configurable: true,
-                    },
+                        configurable: true},
                     reply: {
                         /**
                          * Reply to quoted message
@@ -2209,8 +2159,7 @@ export function serialize() {
                         value(text, chatId, options) {
                             return self.conn?.reply(chatId ? chatId : this.chat, text, this.vM, options)
                         },
-                        enumerable: true,
-                    },
+                        enumerable: true},
                     copy: {
                         /**
                          * Copy quoted message
@@ -2219,8 +2168,7 @@ export function serialize() {
                             const M = proto.WebMessageInfo
                             return smsg(conn, M.fromObject(M.toObject(this.vM)))
                         },
-                        enumerable: true,
-                    },
+                        enumerable: true},
                     forward: {
                         /**
                          * Forward quoted message
@@ -2232,8 +2180,7 @@ export function serialize() {
                                 forward: this.vM, force, ...options
                             }, { ...options })
                         },
-                        enumerable: true,
-                    },
+                        enumerable: true},
                     copyNForward: {
                         /**
                          * Exact Forward quoted message
@@ -2244,9 +2191,7 @@ export function serialize() {
                         value(jid, forceForward = false, options) {
                             return self.conn?.copyNForward(jid, this.vM, forceForward, options)
                         },
-                        enumerable: true,
-
-                    },
+                        enumerable: true},
                     cMod: {
                         /**
                          * Modify quoted Message
@@ -2258,9 +2203,7 @@ export function serialize() {
                         value(jid, text = '', sender = this.sender, options = {}) {
                             return self.conn?.cMod(jid, this.vM, text, sender, options)
                         },
-                        enumerable: true,
-
-                    },
+                        enumerable: true},
                     delete: {
                         /**
                          * Delete quoted message
@@ -2268,9 +2211,7 @@ export function serialize() {
                         value() {
                             return self.conn?.sendMessage(this.chat, { delete: this.vM.key })
                         },
-                        enumerable: true,
-
-                    },
+                        enumerable: true},
                 react: {
                                                 value(text) {
                                                         return self.conn?.sendMessage(this.chat, {
@@ -2280,16 +2221,14 @@ export function serialize() {
                                                                 }
                                                         })
                                                 },
-                                                enumerable: true,
-                                        }
+                                                enumerable: true}
                                 })
                         },
                         enumerable: true
                 },
                 _text: {
                         value: null,
-                        writable: true,
-                },
+                        writable: true},
                 text: {
                         get() {
                 const msg = this.msg

--- a/plugins/_antilink.js
+++ b/plugins/_antilink.js
@@ -41,16 +41,7 @@ text: aviso,
 contextInfo: {
 mentionedJid: [user],
 forwardingScore: 999,
-isForwarded: true,
-externalAdReply: {
-title: `⚡ 𝗔𝗡𝗧𝗜𝗟𝗜𝗡𝗞 𝗔𝗖𝗧𝗜𝗩𝗢 ⚡`,
-body: '¡NO ENVIES LINKS AQUI!',
-thumbnailUrl: 'https://i.pinimg.com/736x/ac/12/6f/ac126f05f2040dd944a4a9d653f84206.jpg',
-sourceUrl: 'https://whatsapp.com/channel/0029VakLbM76mYPPFL0IFI3P',
-mediaType: 1,
-renderLargerThumbnail: false
-}
-}
+isForwarded: true}
 }, { quoted: null });
 
 await conn.groupParticipantsUpdate(m.chat, [user], 'remove');

--- a/plugins/_welcome.js
+++ b/plugins/_welcome.js
@@ -83,16 +83,7 @@ export async function before(m, { conn, participants, groupMetadata }) {
                     mentionedJid: [userId],
                     isForwarded: true,
                     forwardingScore: 9999999,
-                    forwardedNewsletterMessageInfo: { newsletterJid: newsletterJid, newsletterName: newsletterName, serverMessageId: -1 },
-                    externalAdReply: {
-                        title: '  ͟͞ Ｗ Ｅ Ｌ Ｃ Ｏ Ｍ Ｅ ͟͞  ',
-                        body: `✧ ˖ ꒰ ${groupName} ꒱ ˖ ✧`,
-                        thumbnailUrl: getRandomIcono(),
-                        sourceUrl: global.redes || 'https://whatsapp.com/channel/0029Vag9VSI2ZjCocqa2lB1y',
-                        mediaType: 1,
-                        renderLargerThumbnail: false
-                    }
-                }
+                    forwardedNewsletterMessageInfo: { newsletterJid: newsletterJid, newsletterName: newsletterName, serverMessageId: -1 }}
             }, { quoted: null })
         }
 
@@ -133,16 +124,7 @@ export async function before(m, { conn, participants, groupMetadata }) {
                     mentionedJid: [userId],
                     isForwarded: true,
                     forwardingScore: 9999999,
-                    forwardedNewsletterMessageInfo: { newsletterJid: newsletterJid, newsletterName: newsletterName, serverMessageId: -1 },
-                    externalAdReply: {
-                        title: '  ͟͞ Ａ Ｄ Ｉ Ｏ́ Ｓ ͟͞  ',
-                        body: `✧ ˖ ꒰ ${toFancy("Hasta la proxima")} ꒱ ˖ ✧`,
-                        thumbnailUrl: getRandomIcono(),
-                        sourceUrl: global.redes || 'https://whatsapp.com/channel/0029Vag9VSI2ZjCocqa2lB1y',
-                        mediaType: 1,
-                        renderLargerThumbnail: false
-                    }
-                }
+                    forwardedNewsletterMessageInfo: { newsletterJid: newsletterJid, newsletterName: newsletterName, serverMessageId: -1 }}
             }, { quoted: null })
         }
     }

--- a/plugins/anime-frase.js
+++ b/plugins/anime-frase.js
@@ -193,16 +193,7 @@ let handler = async (m, { conn, usedPrefix }) => {
         image: { url: elegido.imagen },
         caption: str,
         contextInfo: {
-            externalAdReply: {
-                mediaUrl: null,
-                mediaType: 3,
-                showAdAttribution: true,
-                title: elegido.personaje,
-                body: wm,
-                previewType: 0,
-                thumbnail: thumb,
-                sourceUrl: channel,
-            },
+            
             forwardedNewsletterMessageInfo: {
                 newsletterJid: '120363335626706839@newsletter',
                 newsletterName: '⛦『 ✎𝐓͢ᴇ𝙖፝ᴍ⃨ 𝘾𝒉꯭𝐚𝑛𝑛𝒆𝑙 𝑹ᴜ⃛ɓ𝑦-𝑯ᴏ⃔𝒔𝑯𝙞꯭𝑛⃡𝒐✎ 』⛦',

--- a/plugins/anime-waifu.js
+++ b/plugins/anime-waifu.js
@@ -13,16 +13,7 @@ let handler = async (m, { conn, usedPrefix, command }) => {
         newsletterJid,
         newsletterName,
         serverMessageId: -1
-      },
-      externalAdReply: {
-        title: packname,
-        body: dev,
-        thumbnail: icons,
-        sourceUrl: redes,
-        mediaType: 1,
-        renderLargerThumbnail: false
-      }
-    };
+      }};
 
     await m.react('🌸');
     await conn.reply(m.chat, '🎀 *Buscando una waifu para ti... espera un momento~*', m, { contextInfo });

--- a/plugins/bot-audios.js
+++ b/plugins/bot-audios.js
@@ -25,15 +25,7 @@ handler.all = async function (m) {
         await this.sendMessage(m.chat, { 
             audio: { url: vn }, 
             contextInfo: { 
-                "externalAdReply": { 
-                    "title": typeof packname != 'undefined' ? packname : 'Bot', 
-                    "body": typeof botname != 'undefined' ? botname : 'WhatsApp Bot', 
-                    "previewType": "PHOTO", 
-                    "thumbnailUrl": null,
-                    "thumbnail": typeof icons != 'undefined' ? icons : null, 
-                    "sourceUrl": typeof redes != 'undefined' ? redes : null, 
-                    "showAdAttribution": true
-                }
+                
             }, 
             ptt: true, 
             mimetype: 'audio/mpeg', 

--- a/plugins/buscador-githubsearch.js
+++ b/plugins/buscador-githubsearch.js
@@ -25,7 +25,7 @@ let str=results.map((repo,index)=>{return `
 `.trim()}).join('\n\n')
 let img=await(await fetch(json.items[0].owner.avatar_url)).buffer()
 let txtHeader=`✿ ㅤ ׄㅤ 🪷̸ㅤ ˒˓ㅤ 𓏸̶ ㅤ ׄ   ✿\n         \`\`\`G I T H U B   S E A R C H\`\`\`\n\n${str}\n\n 𖥻    ·  ˖ ࣪  𓈃    ${toFancy("Búsqueda Finalizada")}    ‧₊˚ ㅤ ☆`
-await conn.sendMessage(m.chat,{text:txtHeader,contextInfo:{externalAdReply:{title:'  ͟͞ Ｇ Ｉ Ｔ Ｈ Ｕ Ｂ ͟͞  ',body:dev||'Github Search Tool',thumbnail:img,sourceUrl:redes||repo.html_url,mediaType:1,renderLargerThumbnail:true}}},{quoted:m})
+await conn.sendMessage(m.chat,{text:txtHeader,contextInfo:{}},{quoted:m})
 await m.react(done)
 }catch(e){
 await m.react(error)

--- a/plugins/descargar-play3xz.js
+++ b/plugins/descargar-play3xz.js
@@ -72,15 +72,7 @@ const handler = async (m, { conn, text, command }) => {
     const thumb = (await conn.getFile(thumbnail))?.data
     await conn.reply(m.chat, infoMessage, m, {
       contextInfo: {
-        externalAdReply: {
-          title: botname,
-          body: dev,
-          mediaType: 1,
-          thumbnail: thumb,
-          renderLargerThumbnail: true,
-          mediaUrl: url,
-          sourceUrl: url
-        }
+        
       }
     })
 

--- a/plugins/descargas-facebook.js
+++ b/plugins/descargas-facebook.js
@@ -40,14 +40,7 @@ return conn.reply(m.chat, '🚩 *ᥒ᥆ ᥱs ᥙᥒ ᥱᥒᥣᥲᥴᥱ ᥎ᥲ́�
 conn.reply(m.chat, '🚀 𝗗𝗲𝘀𝗰𝗮𝗿𝗴𝗮𝗻𝗱𝗼 𝗘𝗹 𝗩𝗶𝗱𝗲𝗼 𝗗𝗲 𝗙𝗮𝗰𝗲𝗯𝗼𝗼𝗸, 𝗘𝘀𝗽𝗲𝗿𝗲 𝗨𝗻 𝗠𝗼𝗺𝗲𝗻𝘁𝗼....', m, {
 contextInfo: { 
 forwardingScore: 2022, 
-isForwarded: true, 
-externalAdReply: {
-title: packname,
-body: '𝙁𝘼𝘾𝙀𝘽𝙊𝙊𝙆 - 𝘿𝙊𝙒𝙉𝙇𝙊𝘼𝘿',
-sourceUrl: redes,
-thumbnail: icons
-}
-}
+isForwarded: true}
 })
 
 m.react(rwait)

--- a/plugins/descargas-instagram.js
+++ b/plugins/descargas-instagram.js
@@ -18,14 +18,7 @@ if (!url.match(/instagram.com|instagr.am|ig.me/)) return conn.reply(m.chat, '�
 await conn.reply(m.chat, '⁖❤️꙰  *Descargando su video de Instagram*', m, {
 contextInfo: { 
 forwardingScore: 2022, 
-isForwarded: true, 
-externalAdReply: {
-title: packname || 'Ruby-Hoshino',
-body: '𝙄𝙉𝙎𝙏𝘼𝙂𝙍𝘼𝙈 - 𝘿𝙊𝙒𝙉𝙇𝙊𝘼𝘿',
-sourceUrl: redes || '',
-thumbnail: icons || null
-}
-}
+isForwarded: true}
 });
 
 m.react && m.react(rwait).catch(()=>{});

--- a/plugins/descargas-modapk.js
+++ b/plugins/descargas-modapk.js
@@ -36,14 +36,7 @@ let handler = async (m, { conn, usedPrefix, command, text }) => {
       image: { url: data5.icon },
       caption: txt,
       contextInfo: {
-        externalAdReply: {
-          title: 'ＤＥＳＣＡＲＧＡＳ ＡＰＫ',
-          body: toFancy('Descargas Rapidas'),
-          thumbnailUrl: data5.icon,
-          sourceUrl: global.channel || 'https://whatsapp.com/channel/0029Vag9VSI2ZjCocqa2lB1y',
-          mediaType: 1,
-          renderLargerThumbnail: false
-        }
+        
       }
     }, { quoted: m })
 

--- a/plugins/descargas-play.js
+++ b/plugins/descargas-play.js
@@ -69,18 +69,7 @@ const handler = async (m, { conn, text, command }) => {
           newsletterJid: newsletterJid,
           newsletterName: newsletterName,
           serverMessageId: -1
-        },
-        externalAdReply: {
-          // Nota: Asegúrate de que 'botname' y 'dev' estén definidos en tu bot globalmente, si no, pon un string fijo.
-          title: typeof botname !== 'undefined' ? botname : 'Bot',
-          body: typeof dev !== 'undefined' ? dev : 'Developer',
-          mediaType: 1,
-          thumbnail: thumbBuffer,
-          renderLargerThumbnail: false,
-          mediaUrl: url,
-          sourceUrl: url
-        }
-      }
+        }}
     })
 
     if (["play", "yta", "ytmp3", "playaudio"].includes(command)) {

--- a/plugins/descargas-spotify.js
+++ b/plugins/descargas-spotify.js
@@ -30,18 +30,7 @@ let handler = async (m, { conn, text, usedPrefix, command }) => {
 
         const info = `「✦」Descargando: ${data.result.data.title}\n\n> 👤 *Artista:* ${data.result.data.artis}\n> 💽 *Álbum:* ${song.album}\n> 🕒 *Duración:* ${timestamp(data.result.data.durasi)}\n> 🔗 *Enlace:* ${song.url}`
 
-        await conn.sendMessage(m.chat, { text: info, contextInfo: { forwardingScore: 9999999, isForwarded: false, 
-        externalAdReply: {
-            showAdAttribution: true,
-            containsAutoReply: true,
-            renderLargerThumbnail: true,
-            title: packname,
-            body: dev,
-            mediaType: 1,
-            thumbnailUrl: data.result.data.image,
-            mediaUrl: data.result.data.download,
-            sourceUrl: data.result.data.download
-        }}}, { quoted: m })
+        await conn.sendMessage(m.chat, { text: info, contextInfo: { forwardingScore: 9999999, isForwarded: false}}, { quoted: m })
 
         conn.sendMessage(m.chat, { audio: { url: data.result.data.download }, fileName: `${data.result.data.title}.mp3`, mimetype: 'audio/mp4', ptt: true }, { quoted: m })
 

--- a/plugins/descargas-tiktok_mp3.js
+++ b/plugins/descargas-tiktok_mp3.js
@@ -12,14 +12,7 @@ conn.sendMessage(m.chat, { react: { text: "🕒", key: m.key } });
       mimetype: 'audio/mp4',
       fileName: `ttbykeni.mp3`,
       contextInfo: {
-        externalAdReply: {
-          showAdAttribution: true,
-          mediaType: 2,
-          mediaUrl: text,
-          title: dp.results.title,
-          sourceUrl: text,
-          thumbnail: await (await conn.getFile(dp.results.thumbnail)).data
-        }
+        
       }
     };
     await conn.sendMessage(m.chat, doc, { quoted: m })

--- a/plugins/grupo-hidetag.js
+++ b/plugins/grupo-hidetag.js
@@ -40,7 +40,7 @@ conn.sendMessage(m.chat, { audio: mediax, mentions: users, mimetype: 'audio/mp4'
 var mediax = await quoted.download?.()
 conn.sendMessage(m.chat, {sticker: mediax, mentions: users}, { quoted: null })
 } else {
-await conn.relayMessage(m.chat, {extendedTextMessage:{text: `${masss}\n${htextos}\n`, ...{ contextInfo: { mentionedJid: users, externalAdReply: { thumbnail: icons, sourceUrl: redes }}}}}, {})
+await conn.relayMessage(m.chat, {extendedTextMessage:{text: `${masss}\n${htextos}\n`, ...{ contextInfo: { mentionedJid: users}}}}, {})
 }}
 
 }

--- a/plugins/grupo-opciones.js
+++ b/plugins/grupo-opciones.js
@@ -46,16 +46,7 @@ const handler = async (m, { conn }) => {
   await conn.sendMessage(m.chat, {
     text,
     contextInfo: {
-      mentionedJid: [chat.botPrimario],
-      externalAdReply: {
-        title: `❖ ${groupName} ❖`,
-        body: '(◍•ᴗ•◍) 𝙲𝙾𝙽𝙵𝙸𝙶𝚄𝚁𝙰𝙲𝙸𝙾́𝙽 𝙳𝙴𝙻 𝙶𝚁𝚄𝙿𝙾',
-        thumbnailUrl: avatar,
-        mediaType: 1,
-        showAdAttribution: true,
-        renderLargerThumbnail: true
-      }
-    }
+      mentionedJid: [chat.botPrimario]}
   }, { quoted: m });
 };
 

--- a/plugins/main-allfake.js
+++ b/plugins/main-allfake.js
@@ -146,21 +146,7 @@ global.rcanal = {
     forwardedNewsletterMessageInfo: {
       newsletterJid: channelRD.id,
       serverMessageId: 100,
-      newsletterName: channelRD.name,
-    },
-    externalAdReply: {
-      showAdAttribution: true,
-      title: botname,
-      body: dev,
-      mediaUrl: null,
-      description: null,
-      previewType: "PHOTO",
-      thumbnail: global.icono,
-      sourceUrl: global.redes,
-      mediaType: 1,
-      renderLargerThumbnail: false
-    },
-  }
+      newsletterName: channelRD.name}}
 }
 
 }

--- a/plugins/main-menu.js
+++ b/plugins/main-menu.js
@@ -690,14 +690,7 @@ let handler = async (m, { conn, args }) => {
     await conn.reply(m.chat, '*ꪹ͜𓂃⌛͡𝗘𝗻𝘃𝗶𝗮𝗻𝗱𝗼 𝗠𝗲𝗻𝘂 𝗱𝗲 𝗹𝗮 𝗕𝗼𝘁....𓏲੭*', m, { 
         contextInfo: { 
             forwardingScore: 2022, 
-            isForwarded: true, 
-            externalAdReply: {
-                title: packname,
-                body: '¡𝙚𝙭𝙥𝙡𝙤𝙧𝙖 𝙡𝙖 𝙜𝙧𝙖𝙣 𝙫𝙖𝙧𝙞𝙚𝙙𝙖𝙙 𝙙𝙚 𝙘𝙤𝙢𝙖𝙣𝙙𝙤𝙨! (˵•̀ᴗ - ˵ )',
-                sourceUrl: redes,
-                thumbnail: icons, 
-            }
-        }
+            isForwarded: true}
     });
 
 
@@ -714,17 +707,7 @@ let handler = async (m, { conn, args }) => {
             forwardedNewsletterMessageInfo: {
                 newsletterJid: '120363335626706839@newsletter',
                 newsletterName: '..⃗. 💌 ⌇ ¡Noticias y más de tu idol favorita! ⊹ ִ ּ',
-                serverMessageId: -1,
-            },
-            externalAdReply: {
-                title: 'ׄ⏤͟͟͞͞◯⃞ 🎄 𝐑υ𝐛ყ 𝐇ᨵׁׅׅ𝐬𝐡𝐢𝐧ᨵׁׅׅ𖹭 𝐁ᨵׁׅׅ𝐭 𝐌𝐃 ིྀ 🍧',
-                body: dev,
-                thumbnail: icons,
-                sourceUrl: redes,
-                mediaType: 1,
-                renderLargerThumbnail: false,
-            }
-        }
+                serverMessageId: -1}}
     }, { quoted: m });
 
 };

--- a/plugins/main-menumanual.js
+++ b/plugins/main-menumanual.js
@@ -58,15 +58,7 @@ forwardedNewsletterMessageInfo: {
 newsletterJid: channelRD,
 newsletterName: canalNombreM,
 serverMessageId: -1
-},
-externalAdReply: {
-title: packname,
-body: "💗 𓈒꒰ 𝘔𝘦𝘯𝘶 𝘦𝘯𝘷𝘪𝘢𝘥𝘰 ꒱",
-mediaType: 1,
-thumbnail: icons,
-renderLargerThumbnail: false
-}
-}
+}}
 },
 { quoted: m }
 )

--- a/plugins/main-menuowner.js
+++ b/plugins/main-menuowner.js
@@ -104,14 +104,7 @@ let owner = `
 await conn.sendMessage(m.chat, {
 text: owner,
 contextInfo: {
-externalAdReply: {
-title: packname,
-body: dev,
-thumbnailUrl: banner,
-mediaType: 1,
-showAdAttribution: true,
-renderLargerThumbnail: true
-}
+
 }
 }, { quoted: m });
 };

--- a/plugins/main-script.js
+++ b/plugins/main-script.js
@@ -18,7 +18,7 @@ txt += `✩  *Forks* : ${json.forks_count}\n`
 txt += `✩  *Stars* : ${json.stargazers_count}\n\n`
 txt += `> *${dev}*`
 
-await conn.sendMessage(m.chat, {text: txt, contextInfo: { forwardingScore: 999, isForwarded: true, forwardedNewsletterMessageInfo: { newsletterName: channelRD.name, newsletterJid: channelRD.id, }, externalAdReply: { title: packname, body: dev, thumbnailUrl: 'https://files.catbox.moe/467oad.jpg', sourceUrl: redes, mediaType: 1, renderLargerThumbnail: true }}}, {quoted: m})
+await conn.sendMessage(m.chat, {text: txt, contextInfo: { forwardingScore: 999, isForwarded: true, forwardedNewsletterMessageInfo: { newsletterName: channelRD.name, newsletterJid: channelRD.id}}}, {quoted: m})
 
 } catch (e) {
 await conn.reply(m.chat, `${msm} Ocurrió un error.`, m)

--- a/plugins/menustickers.js
+++ b/plugins/menustickers.js
@@ -27,20 +27,7 @@ let handler = async (m, { conn }) => {
     image: { url: 'https://files.catbox.moe/61219t.png' },
     caption: texto,
     contextInfo: {
-      mentionedJid: [m.sender],
-      externalAdReply: {
-        title: '💫 Comandos de diferentes tipos generadores de stickers',
-        body: 'Crea y personaliza tus propios stickers',
-        thumbnailUrl: 'https://files.catbox.moe/hdr7oh.jpg',
-        mediaType: 1,
-        renderLargerThumbnail: false,
-        showAdAttribution: true,
-        mediaUrl: 'https://whatsapp.com/channel/0029VakLbM76mYPPFL0IFI3P',
-        sourceUrl: 'https://whatsapp.com/channel/0029VakLbM76mYPPFL0IFI3P',
-        newsletterJid: '120363335626706839@newsletter',
-        newsletterName: '⏤͟͞ू⃪፝͜⁞⟡『 𝙍𝙪𝙗𝙮 𝙃𝙤𝙨𝙝𝙞𝙣𝙤 𝘽𝙤𝙩 』࿐⟡'
-      }
-    }
+      mentionedJid: [m.sender]}
   }, { quoted: m });
 };
 

--- a/plugins/owner-inspectador.js
+++ b/plugins/owner-inspectador.js
@@ -123,16 +123,7 @@ return
 }}}
 if (info) {
 await conn.sendMessage(m.chat, { text: info, contextInfo: {
-mentionedJid: conn.parseMention(info),
-externalAdReply: {
-title: `${emoji} Inspector de Grupos`,
-body: `${emoji2} ¡Super Inspectador!`,
-thumbnailUrl: pp ? pp : thumb,
-sourceUrl: args[0] ? args[0] : inviteCode ? `https://chat.whatsapp.com/${inviteCode}` : md,
-mediaType: 1,
-showAdAttribution: false,
-renderLargerThumbnail: false
-}}}, { quoted: fkontak })
+mentionedJid: conn.parseMention(info)}}, { quoted: fkontak })
 } else {
 // Manejo de enlaces de canales
 let newsletterInfo
@@ -149,16 +140,7 @@ pp = thumb
 }
 if (channelUrl && newsletterInfo) {
 await conn.sendMessage(m.chat, { text: caption, contextInfo: {
-mentionedJid: conn.parseMention(caption),
-externalAdReply: {
-title: `${emoji} Inspector de Canales`,
-body: `${emoji2} ¡Super Inspectador!`,
-thumbnailUrl: pp,
-sourceUrl: args[0],
-mediaType: 1,
-showAdAttribution: false,
-renderLargerThumbnail: false
-}}}, { quoted: fkontak })}
+mentionedJid: conn.parseMention(caption)}}, { quoted: fkontak })}
 newsletterInfo.id ? conn.sendMessage(m.chat, { text: newsletterInfo.id }, { quoted: null }) : ''
 } catch (e) {
 reportError(e)
@@ -283,15 +265,7 @@ const chtitle = await conn.newsletterMetadata(text.includes("@newsletter") ? "ji
 await conn.newsletterUpdatePicture(ch, media)
 // await conn.reply(m.chat, `${emoji} El bot ha cambiando la imagen del canal *${chtitle}* con éxito.`, m) 
 await conn.sendMessage(ch, { text: `${emoji} ${botname} ha cambiando la imagen del canal *${chtitle}* con éxito.`, contextInfo: {
-externalAdReply: {
-title: "【 🔔 𝐍𝐎𝐓𝐈𝐅𝐈𝐂𝐀𝐂𝐈𝐎́𝐍 🔔 】",
-body: '🍬 𝙽𝚞𝚎𝚟𝚊 𝚏𝚘𝚝𝚘 𝚙𝚊𝚛𝚊 𝚙𝚎𝚛𝚏𝚒𝚕 𝚍𝚎𝚕 𝚌𝚊𝚗𝚊𝚕.',
-thumbnailUrl: pp,
-sourceUrl: redes,
-mediaType: 1,
-showAdAttribution: false,
-renderLargerThumbnail: false
-}}}, { quoted: null })
+}}, { quoted: null })
 } catch (e) {
 reportError(e)
 }
@@ -312,15 +286,7 @@ const chtitle = await conn.newsletterMetadata(text.includes("@newsletter") ? "ji
 await conn.newsletterRemovePicture(ch)
 // await conn.reply(m.chat, `🍦 El bot ha eliminado la imagen del canal *${chtitle}* con éxito.`, m, rcanal) 
 await conn.sendMessage(ch, { text: `🍬 ${botname} ha eliminado la imagen del canal *${chtitle}* con éxito.`, contextInfo: {
-externalAdReply: {
-title: "【 🔔 𝐍𝐎𝐓𝐈𝐅𝐈𝐂𝐀𝐂𝐈𝐎́𝐍 🔔 】",
-body: '🍦 𝙵𝚘𝚝𝚘 𝚍𝚎 𝚙𝚎𝚛𝚏𝚕 𝚍𝚎𝚕 𝚌𝚊𝚗𝚊𝚕 𝚎𝚕𝚒𝚖𝚒𝚗𝚊𝚍𝚊.',
-thumbnailUrl: pp,
-sourceUrl: redes,
-mediaType: 1,
-showAdAttribution: false,
-renderLargerThumbnail: false
-}}}, { quoted: null })
+}}, { quoted: null })
 } catch (e) {
 reportError(e)
 }
@@ -404,15 +370,7 @@ const chtitle = await conn.newsletterMetadata(ch.includes("@newsletter") ? "jid"
 await conn.newsletterReactionMode(ch, mode)
 // await conn.reply(m.chat, `${emoji} El bot ha establecido el modo de reacciones como \`"${mode}"\` para el canal *${chtitle}*`, m)
 await conn.sendMessage(ch, { text: `${emoji} ${botname} ha establecido el modo de reacciones como \`"${mode}"\` para el canal *${chtitle}*`, contextInfo: {
-externalAdReply: {
-title: "【 🔔 𝐍𝐎𝐓𝐈𝐅𝐈𝐂𝐀𝐂𝐈𝐎́𝐍 🔔 】",
-body: '🍭 𝙰𝚓𝚞𝚜𝚝𝚎𝚜 𝚎𝚗 𝚛𝚎𝚊𝚌𝚌𝚒𝚘𝚗𝚎𝚜.',
-thumbnailUrl: pp,
-sourceUrl: redes,
-mediaType: 1,
-showAdAttribution: false,
-renderLargerThumbnail: false
-}}}, { quoted: null })
+}}, { quoted: null })
 } catch (e) {
 reportError(e)
 }
@@ -440,15 +398,7 @@ const chtitle = await conn.newsletterMetadata(text.includes("@newsletter") ? "ji
 await conn.newsletterUpdateName(ch, name)
 // await conn.reply(m.chat, `${emoji} El bot ha cambiado el nombre del canal *${name}*\n\n*Anterior nombre:* ${chtitle}\n*Nuevo nombre:* ${name}`, m) 
 await conn.sendMessage(ch, { text: `${emoji} ${botname} ha cambiado el nombre del canal *${name}*\n\n*Anterior nombre:* ${chtitle}\n*Nuevo nombre:* ${name}`, contextInfo: {
-externalAdReply: {
-title: "【 🔔 𝐍𝐎𝐓𝐈𝐅𝐈𝐂𝐀𝐂𝐈𝐎́𝐍 🔔 】",
-body: '🍧 𝚄𝚗 𝚗𝚞𝚎𝚟𝚘 𝚗𝚘𝚖𝚋𝚛𝚎 𝚙𝚊𝚛𝚊 𝚎𝚕 𝚌𝚊𝚗𝚊𝚕.',
-thumbnailUrl: pp,
-sourceUrl: redes,
-mediaType: 1,
-showAdAttribution: false,
-renderLargerThumbnail: false
-}}}, { quoted: null })
+}}, { quoted: null })
 } catch (e) {
 reportError(e)
 }
@@ -475,15 +425,7 @@ const chtitle = await conn.newsletterMetadata(text.includes("@newsletter") ? "ji
 await conn.newsletterUpdateDescription(ch, description)
 // await conn.reply(m.chat, `${emoji} El bot ha modificado la descripción del canal *${chtitle}*`, m) 
 await conn.sendMessage(ch, { text: `${emoji} ${botname} ha modificado la descripción del canal *${chtitle}*`, contextInfo: {
-externalAdReply: {
-title: "【 🔔 𝐍𝐎𝐓𝐈𝐅𝐈𝐂𝐀𝐂𝐈𝐎́𝐍 🔔 】",
-body: '🍨 𝚄𝚗𝚊 𝚗𝚞𝚎𝚟𝚊 𝚍𝚎𝚜𝚌𝚛𝚒𝚙𝚌𝚒𝚘́𝚗 𝚊𝚕 𝚌𝚊𝚗𝚊𝚕.',
-thumbnailUrl: pp,
-sourceUrl: redes,
-mediaType: 1,
-showAdAttribution: false,
-renderLargerThumbnail: false
-}}}, { quoted: null })
+}}, { quoted: null })
 } catch (e) {
 reportError(e)
 }

--- a/plugins/rg-confesar.js
+++ b/plugins/rg-confesar.js
@@ -24,16 +24,7 @@ let handler = async (m, { conn, text, usedPrefix, command }) => {
         let sentMessage = await conn.sendMessage(data.jid, {
             text: teks,
             contextInfo: {
-                mentionedJid: [data.jid],
-                externalAdReply: {
-                    title: 'C O N F E S I O N E S',
-                    body: '¡responder! .respuesta (id) (Mensaje)',
-                    mediaType: 1,
-                    renderLargerThumbnail: true,
-                    thumbnailUrl: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRIyz1dMPkZuNleUyfXPMsltHwKKdVddTf4-A&usqp=CAU',
-                    sourceUrl: channel,
-                }
-            }
+                mentionedJid: [data.jid]}
         });
         
         

--- a/plugins/rg-perfil.js
+++ b/plugins/rg-perfil.js
@@ -98,15 +98,7 @@ let handler = async (m, { conn }) => {
       {
         text: profileText,
         contextInfo: {
-          mentionedJid: mentions,
-          externalAdReply: {
-            title: '𝘵𝘶 𝘱𝘦𝘳𝘧𝘪𝘭 (*•̀ᴗ•́*)و ̑̑',
-            body: "﹙𖤍﹚ 𝘪𝘯𝘧𝘰𝘳𝘮𝘢𝘤𝘪𝘰 𝘥𝘦𝘭 𝘶𝘴𝘶𝘢𝘳𝘪𝘰.",
-            thumbnailUrl: perfil,
-            mediaType: 1,
-            renderLargerThumbnail: true
-          }
-        }
+          mentionedJid: mentions}
       },
       { quoted: m }
     )

--- a/plugins/rg-respuesta.js
+++ b/plugins/rg-respuesta.js
@@ -28,16 +28,7 @@ let handler = async (m, { conn, text, usedPrefix, command }) => {
         let sentMessage = await conn.sendMessage(dari, {
             text: teks,
             contextInfo: {
-                mentionedJid: [dari],
-                externalAdReply: {
-                    title: 'R E S P U E S T A S',
-                    body: '¡Gracias por usar el servicio de confesiones!',
-                    mediaType: 1,
-                    renderLargerThumbnail: true,
-                    thumbnailUrl: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRIyz1dMPkZuNleUyfXPMsltHwKKdVddTf4-A&usqp=CAU',
-                    sourceUrl: channel,
-                }
-            }
+                mentionedJid: [dari]}
         });
         
         if (sentMessage) {


### PR DESCRIPTION
### Motivation
- WhatsApp channel preview attachments (`externalAdReply`) are no longer reliable, so the bot should stop sending that metadata to avoid broken previews or icons.
- Preserve existing contextual data (mentions, forwarding/newsletter info) while removing the deprecated preview objects to keep message behavior intact.

### Description
- Removed `externalAdReply` object literals from message payloads across `lib/` and `plugins/` code paths and kept `contextInfo` properties such as `mentionedJid`, `isForwarded` and `forwardedNewsletterMessageInfo` where present.
- Cleaned up surrounding payload objects to avoid trailing commas or malformed JSON after removals and adjusted calls to `generateWAMessageFromContent` / `conn.sendMessage` accordingly.
- Changes touch multiple files under `lib/` and `plugins/` (27 JS files modified, e.g. `lib/simple.js`, `lib/respuesta.js`, `plugins/main-menu.js`, `plugins/descargas-play.js`, `plugins/_welcome.js`, `plugins/rg-perfil.js`, etc.).
- Left only a non-functional log string referencing `externalAdReply` in `lib/respuesta.js` for debugging; no payloads include the preview metadata anymore.

### Testing
- Searched repository to confirm removals with `rg -n "externalAdReply|externareply|externalReply|adReply" lib plugins`, which returned only the remaining non-payload log reference and no active payload usages (success).
- Per-file syntax checks were executed using `for f in $(git diff --name-only -- '*.js'); do node --check "$f" || exit 1; done`, and all modified files passed `node --check` (success).
- Additional validation ensured `generateWAMessageFromContent` and `conn.relayMessage` calls remain syntactically correct after the edits (syntax checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0506af93ac832aac73a28581e66da7)