### PR TITLE
Fix admin detection and group user matching for LID/JID

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -17,6 +17,7 @@ global.uptimeStart = Date.now();
 const STALE_MESSAGE_WINDOW_MS = 10 * 60 * 1000
 const GROUP_METADATA_CACHE_TTL_MS = 2 * 60 * 1000
 global.groupMetadataCache = global.groupMetadataCache || new Map()
+const jidLocal = (jid = '') => String(jid || '').split('@')[0].split(':')[0]
 export async function handler(chatUpdate) {
 this.msgqueque = this.msgqueque || []
 this.uptime = this.uptime || Date.now()
@@ -71,6 +72,8 @@ if (jid && !/@/.test(jid)) {
 if (/^\d+$/.test(jid)) jid = jid + '@s.whatsapp.net'
 }
 let lid = p?.lid ?? (jid ? jid.split('@')[0] + '@lid' : undefined)
+if (p?.pn_lid) lid = p.pn_lid
+if (p?.phoneNumberLid) lid = p.phoneNumberLid
 let admin = false
 if (p) {
 if (typeof p.admin === 'string') {
@@ -184,6 +187,21 @@ if (!m.fromMe && opts['self']) return
 if (opts['swonly'] && m.chat !== 'status@broadcast') return
 if (typeof m.text !== 'string') m.text = ''
 const _user = global.db.data.users[sender]
+if (sender?.endsWith('@lid') && m.isGroup) {
+const participantMatch = participants.find(p => jidLocal(p?.id) === jidLocal(sender) && p?.id?.endsWith('@s.whatsapp.net'))
+if (participantMatch?.id) {
+const lidKey = sender
+const canonical = participantMatch.id
+if (!global.db.data.users[canonical]) global.db.data.users[canonical] = {}
+if (global.db.data.users[lidKey]) {
+global.db.data.users[canonical] = { ...global.db.data.users[lidKey], ...global.db.data.users[canonical] }
+delete global.db.data.users[lidKey]
+}
+sender = canonical
+if (m.key) m.key.participant = canonical
+m.sender = canonical
+}
+}
 const findParticipant = (jidToFind) => {
 if (!jidToFind) return undefined
 const target = (this.decodeJid && typeof this.decodeJid === 'function') ? this.decodeJid(jidToFind) : jidToFind
@@ -193,6 +211,8 @@ if (!u) return false
 if (u.jid && this.decodeJid && this.decodeJid(u.jid) === target) return true
 if (u.id && this.decodeJid && this.decodeJid(u.id) === target) return true
 if (u.lid && target && (u.lid === target || u.lid === jidToFind)) return true
+const targetLocal = jidLocal(target)
+if (targetLocal && (jidLocal(u.jid) === targetLocal || jidLocal(u.id) === targetLocal || jidLocal(u.lid) === targetLocal)) return true
 } catch (e) { }
 return false
 })

--- a/plugins/rpg-baltop.js
+++ b/plugins/rpg-baltop.js
@@ -1,8 +1,9 @@
 let handler = async (m, { conn, args, participants }) => {
-const groupJids = participants.map(p => p.id)
+const jidLocal = jid => String(jid || '').split('@')[0].split(':')[0]
+const groupLocals = new Set(participants.map(p => jidLocal(p.id)).filter(Boolean))
 
 const users = Object.entries(global.db.data.users)
-.filter(([jid]) => groupJids.includes(jid))
+.filter(([jid]) => groupLocals.has(jidLocal(jid)))
 .map(([key, value]) => ({ ...value, jid: key }))
 
 const sorted = users.sort((a, b) => {


### PR DESCRIPTION
### Motivation
- Resolver fallos donde la bot o usuarios admin no se detectaban correctamente en grupos por diferencias entre `@lid` y `@s.whatsapp.net` en metadatos de Baileys.
- Evitar entradas duplicadas/fragmentadas en la DB (coins, perfil) causadas por claves guardadas con distintos dominios JID/LID.
- Restaurar comandos como `baltop` que mostraban `undefined` por no casar usuarios cuando el dominio JID variaba.

### Description
- Añadí el helper `jidLocal` para normalizar la parte local del JID y usarla para comparaciones entre variantes JID/LID. 
- Soporte para campos nuevos de Baileys en participantes (`pn_lid`, `phoneNumberLid`) al construir la lista de `participants` en `handler.js`.
- Implementé migración automática durante el manejo de mensajes para mover datos de usuario guardados bajo `@lid` a la clave canónica `@s.whatsapp.net` cuando se detecta la contraparte canónica en el grupo. 
- Mejoré `findParticipant` para comparar por `decodeJid` y también por la parte local normalizada, y actualicé `plugins/rpg-baltop.js` para filtrar usuarios del grupo por la parte local en vez de por JID exacto.

### Testing
- Ejecutado `node --check handler.js` y la comprobación de sintaxis pasó correctamente. ✅
- Ejecutado `node --check plugins/rpg-baltop.js` y la comprobación de sintaxis pasó correctamente. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08dd006bfc832ab68d80c67a766f62)