### PR TITLE
Normalize participant JIDs, resolve legacy `@lid` identifiers, and fix group leaderboard filtering

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -17,6 +17,14 @@ global.uptimeStart = Date.now();
 const STALE_MESSAGE_WINDOW_MS = 10 * 60 * 1000
 const GROUP_METADATA_CACHE_TTL_MS = 2 * 60 * 1000
 global.groupMetadataCache = global.groupMetadataCache || new Map()
+const jidLocal = (jid = '') => String(jid || '').split('@')[0].split(':')[0]
+const asUserJid = (value = '') => {
+const v = String(value || '').trim()
+if (!v) return ''
+if (v.includes('@')) return v
+const digits = v.replace(/[^0-9]/g, '')
+return digits ? `${digits}@s.whatsapp.net` : ''
+}
 export async function handler(chatUpdate) {
 this.msgqueque = this.msgqueque || []
 this.uptime = this.uptime || Date.now()
@@ -66,11 +74,14 @@ global.groupMetadataCache.set(m.chat, { data: freshMetadata, ts: Date.now() })
 }
 const rawParticipants = m.isGroup ? (groupMetadata.participants || []) : []
 const participants = (rawParticipants || []).map(p => {
-let jid = typeof p === 'string' ? p : (p.id || p.jid || p.participant || p?.[0] || null)
+let jid = typeof p === 'string' ? p : (p.jid || p.id || p.participant || p.phoneNumber || p?.[0] || null)
+jid = asUserJid(jid)
 if (jid && !/@/.test(jid)) {
 if (/^\d+$/.test(jid)) jid = jid + '@s.whatsapp.net'
 }
-let lid = p?.lid ?? (jid ? jid.split('@')[0] + '@lid' : undefined)
+let lid = p?.lid ?? p?.pn_lid ?? p?.phoneNumberLid ?? (jid ? jid.split('@')[0] + '@lid' : undefined)
+if (p?.pn_lid) lid = p.pn_lid
+if (p?.phoneNumberLid) lid = p.phoneNumberLid
 let admin = false
 if (p) {
 if (typeof p.admin === 'string') {
@@ -87,11 +98,12 @@ if (p.role === 'creator') admin = 'superadmin'
 else if (p.role === 'admin') admin = 'admin'
 }
 }
-return { id: jid, jid: jid, lid, admin }
+return { id: jid, jid: jid, lid, admin, phoneNumber: asUserJid(p?.phoneNumber || '') }
 })
 if (m.isGroup) {
 if (sender && sender.endsWith('@lid')) {
-const pInfo = participants.find(p => p.lid === sender)
+const senderLocal = jidLocal(sender)
+const pInfo = participants.find(p => p.lid === sender || jidLocal(p.lid) === senderLocal || jidLocal(p.id) === senderLocal)
 if (pInfo && pInfo.id) {
 sender = pInfo.id
 if (m.key) m.key.participant = pInfo.id
@@ -99,7 +111,8 @@ try { m.sender = pInfo.id } catch (e) { }
 }
 }
 if (m.quoted && m.quoted.sender && m.quoted.sender.endsWith('@lid')) {
-const pInfo = participants.find(p => p.lid === m.quoted.sender)
+const quotedLocal = jidLocal(m.quoted.sender)
+const pInfo = participants.find(p => p.lid === m.quoted.sender || jidLocal(p.lid) === quotedLocal || jidLocal(p.id) === quotedLocal)
 if (pInfo && pInfo.id) {
 if (m.quoted.key) m.quoted.key.participant = pInfo.id
 try { m.quoted.sender = pInfo.id } catch (e) { }
@@ -108,7 +121,8 @@ try { m.quoted.sender = pInfo.id } catch (e) { }
 if (m.mentionedJid && m.mentionedJid.length > 0) {
 const normalizedMentions = m.mentionedJid.map(jid => {
 if (jid && jid.endsWith('@lid')) {
-const pInfo = participants.find(p => p.lid === jid)
+const mentionLocal = jidLocal(jid)
+const pInfo = participants.find(p => p.lid === jid || jidLocal(p.lid) === mentionLocal || jidLocal(p.id) === mentionLocal)
 return (pInfo && pInfo.id) ? pInfo.id : jid
 }
 return jid
@@ -118,6 +132,21 @@ try { m.mentionedJid = normalizedMentions } catch (e) { }
 }
 m.exp = 0
 m.coin = false
+if (sender?.endsWith('@lid') && m.isGroup) {
+const participantMatch = participants.find(p => jidLocal(p?.id) === jidLocal(sender) && p?.id?.endsWith('@s.whatsapp.net'))
+if (participantMatch?.id) {
+const lidKey = sender
+const canonical = participantMatch.id
+if (!global.db.data.users[canonical]) global.db.data.users[canonical] = {}
+if (global.db.data.users[lidKey]) {
+global.db.data.users[canonical] = { ...global.db.data.users[lidKey], ...global.db.data.users[canonical] }
+delete global.db.data.users[lidKey]
+}
+sender = canonical
+if (m.key) m.key.participant = canonical
+m.sender = canonical
+}
+}
 const userDefault = {
 exp: 0, coin: 10, joincount: 1, diamond: 3, lastadventure: 0, health: 100,
 lastclaim: 0, lastcofre: 0, lastdiamantes: 0, lastcode: 0, lastduel: 0,
@@ -193,6 +222,8 @@ if (!u) return false
 if (u.jid && this.decodeJid && this.decodeJid(u.jid) === target) return true
 if (u.id && this.decodeJid && this.decodeJid(u.id) === target) return true
 if (u.lid && target && (u.lid === target || u.lid === jidToFind)) return true
+const targetLocal = jidLocal(target)
+if (targetLocal && (jidLocal(u.jid) === targetLocal || jidLocal(u.id) === targetLocal || jidLocal(u.lid) === targetLocal)) return true
 } catch (e) { }
 return false
 })
@@ -209,8 +240,8 @@ const botGroup = (m.isGroup ? findParticipant(this.user.jid) : {}) || {}
 const isRAdmin = normalizeAdmin(userGroup) === 'superadmin'
 const isAdmin = isRAdmin || normalizeAdmin(userGroup) === 'admin'
 const isBotAdmin = normalizeAdmin(botGroup) === 'admin' || normalizeAdmin(botGroup) === 'superadmin'
-const senderNum = String(sender || '').split('@')[0];
-const isROwner = global.owner.map(([number]) => number).includes(senderNum);
+const senderNum = jidLocal(sender);
+const isROwner = global.owner.map(([number]) => String(number).replace(/[^0-9]/g, '')).includes(senderNum);
 const isOwner = isROwner
 const isMods = isOwner || global.mods.map(v => v.replace(/[^0-9]/g, '')).includes(senderNum)
 const isPrems = isROwner || global.prems.map(v => v.replace(/[^0-9]/g, '')).includes(senderNum) || _user?.premium == true

--- a/plugins/rpg-baltop.js
+++ b/plugins/rpg-baltop.js
@@ -1,8 +1,9 @@
 let handler = async (m, { conn, args, participants }) => {
-const groupJids = participants.map(p => p.id)
+const jidLocal = jid => String(jid || '').split('@')[0].split(':')[0]
+const groupLocals = new Set(participants.map(p => jidLocal(p.id)).filter(Boolean))
 
 const users = Object.entries(global.db.data.users)
-.filter(([jid]) => groupJids.includes(jid))
+.filter(([jid]) => groupLocals.has(jidLocal(jid)))
 .map(([key, value]) => ({ ...value, jid: key }))
 
 const sorted = users.sort((a, b) => {


### PR DESCRIPTION
### Motivation
- Participant identifiers can arrive in different shapes (`jid`, `id`, `participant`, `phoneNumber`, `pn_lid`, etc.) and legacy local IDs (`@lid`) were not always normalized to canonical user JIDs, causing mismatches and broken features. 
- The bot must reliably resolve senders, quoted messages, and mentions when group metadata provides phone-number-based or lid-based identifiers. 
- Group-scoped features such as the `rpg-baltop` leaderboard must match users using a local-id-insensitive comparison to include the right users.

### Description
- Added helper utilities `jidLocal` and `asUserJid` to normalize JID strings and convert phone-like values into `@s.whatsapp.net` user JIDs. 
- Improved participant parsing to accept multiple fields (`p.jid`, `p.id`, `p.participant`, `p.phoneNumber`) and normalize those values with `asUserJid`, and to read lids from `p.lid`, `p.pn_lid`, or `p.phoneNumberLid`. 
- Enhanced resolution logic for message `sender`, `m.quoted.sender`, and `m.mentionedJid` to match by local ID (`jidLocal`) in addition to exact lids, and to update message keys to canonical `@s.whatsapp.net` JIDs when a match is found. 
- When a `@lid` key is detected for the sender, merge any user data from the lid-keyed entry into the canonical user record and remove the old lid entry in `global.db.data.users`. 
- Updated `findParticipant` to consider local-id equality (via `jidLocal`) when searching participant lists. 
- Adjusted owner/mods/prems checks to use `jidLocal` and numeric-only comparison to avoid mismatches. 
- Fixed `plugins/rpg-baltop.js` to build a `groupLocals` set using `jidLocal` and to filter `global.db.data.users` based on local-id equality so leaderboard entries include matching users regardless of jid form.

### Testing
- Ran the repository test suite via `npm test` and the automated tests completed successfully. 
- Ran linting via `npm run lint` and no lint issues were reported. 
- Executed automated smoke tests simulating group messages and leaderboard generation against the modified handler, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08dd006bfc832ab68d80c67a766f62)