### PR TITLE
Add group message activity ranking (topmensajes) and passive stats collector

### DIFF
--- a/plugins/_message-stats.js
+++ b/plugins/_message-stats.js
@@ -1,0 +1,69 @@
+const DAY_MS = 24 * 60 * 60 * 1000
+const MAX_DAYS_TO_KEEP = 45
+
+const normalizeJid = jid => typeof jid === 'string' ? jid.split(':')[0] : jid
+
+const getDayKey = (time = Date.now()) => {
+  const date = new Date(time)
+  return date.toISOString().slice(0, 10)
+}
+
+const normalizePrefixList = prefix => {
+  if (Array.isArray(prefix)) return prefix
+  if (prefix instanceof RegExp) return [prefix]
+  if (typeof prefix === 'string') return [prefix]
+  return ['#', '.', '/', '!']
+}
+
+const isCommandMessage = (text, conn) => {
+  if (!text || typeof text !== 'string') return false
+  const prefixes = normalizePrefixList(conn?.prefix || global.prefix)
+  return prefixes.some(prefix => {
+    if (prefix instanceof RegExp) return prefix.test(text)
+    return text.startsWith(prefix)
+  })
+}
+
+const pruneOldDays = (users, now = Date.now()) => {
+  const minTime = now - (MAX_DAYS_TO_KEEP * DAY_MS)
+  for (const user of Object.values(users)) {
+    if (!user || typeof user !== 'object' || !user.days) continue
+    for (const day of Object.keys(user.days)) {
+      const dayTime = new Date(`${day}T00:00:00.000Z`).getTime()
+      if (!Number.isFinite(dayTime) || dayTime < minTime) delete user.days[day]
+    }
+  }
+}
+
+let handler = m => m
+
+handler.before = async function (m) {
+  if (!m?.isGroup || !m.sender || m.fromMe || m._messageStatsCounted) return false
+  if (!global.db?.data?.chats?.[m.chat]) return false
+
+  m._messageStatsCounted = true
+
+  const chat = global.db.data.chats[m.chat]
+  chat.messageStats = chat.messageStats && typeof chat.messageStats === 'object' ? chat.messageStats : {}
+  chat.messageStats.users = chat.messageStats.users && typeof chat.messageStats.users === 'object' ? chat.messageStats.users : {}
+
+  const sender = normalizeJid(m.sender)
+  const now = Date.now()
+  const day = getDayKey(now)
+  const users = chat.messageStats.users
+  const user = users[sender] || (users[sender] = { name: '', days: {} })
+  const bucket = user.days[day] || (user.days[day] = { messages: 0, commands: 0 })
+
+  user.name = m.name || m.pushName || user.name || sender.split('@')[0]
+  user.lastSeen = now
+  bucket.messages += 1
+  if (isCommandMessage(m.text, this)) bucket.commands += 1
+
+  chat.messageStats.updatedAt = now
+  chat.messageStats.keepDays = MAX_DAYS_TO_KEEP
+  pruneOldDays(users, now)
+
+  return false
+}
+
+export default handler

--- a/plugins/grupo-topmensajes.js
+++ b/plugins/grupo-topmensajes.js
@@ -1,0 +1,83 @@
+const DAY_MS = 24 * 60 * 60 * 1000
+const DEFAULT_DAYS = 30
+const PER_PAGE = 10
+
+const normalizeJid = jid => typeof jid === 'string' ? jid.split(':')[0] : jid
+
+const dayKey = time => new Date(time).toISOString().slice(0, 10)
+
+const getDaysToCount = days => {
+  const now = Date.now()
+  const keys = new Set()
+  for (let i = 0; i < days; i++) keys.add(dayKey(now - (i * DAY_MS)))
+  return keys
+}
+
+const parsePositiveInt = value => {
+  const number = Number.parseInt(value, 10)
+  return Number.isFinite(number) && number > 0 ? number : null
+}
+
+let handler = async (m, { conn, args, usedPrefix, participants }) => {
+  const first = parsePositiveInt(args[0])
+  const second = parsePositiveInt(args[1])
+  const days = second ? Math.min(first || DEFAULT_DAYS, 45) : DEFAULT_DAYS
+  const page = Math.max(second || first || 1, 1)
+
+  const chat = global.db.data.chats[m.chat] || {}
+  const stats = chat.messageStats?.users || {}
+  const validDays = getDaysToCount(days)
+  const participantIds = new Set((participants || []).map(p => normalizeJid(p.id || p.jid)).filter(Boolean))
+
+  const ranking = Object.entries(stats).map(([jid, user]) => {
+    let messages = 0
+    let commands = 0
+    for (const [date, bucket] of Object.entries(user?.days || {})) {
+      if (!validDays.has(date)) continue
+      messages += Number(bucket.messages) || 0
+      commands += Number(bucket.commands) || 0
+    }
+    return {
+      jid: normalizeJid(jid),
+      name: user?.name || jid.split('@')[0],
+      messages,
+      commands,
+      active: participantIds.size ? participantIds.has(normalizeJid(jid)) : true
+    }
+  }).filter(user => user.messages > 0 && user.active)
+    .sort((a, b) => (b.messages - a.messages) || (b.commands - a.commands))
+
+  if (!ranking.length) {
+    return m.reply(`❀ Aún no tengo mensajes registrados en este grupo.\n\n> Escribe un poco más y vuelve a usar *${usedPrefix}topmensajes*.`)
+  }
+
+  const totalPages = Math.max(Math.ceil(ranking.length / PER_PAGE), 1)
+  const safePage = Math.min(page, totalPages)
+  const start = (safePage - 1) * PER_PAGE
+  const pageItems = ranking.slice(start, start + PER_PAGE)
+
+  const lines = [`❀ Top de mensajes en los últimos *${days}* días`, '']
+  for (const [index, user] of pageItems.entries()) {
+    let name = user.name
+    try { name = await conn.getName(user.jid) || name } catch (e) {}
+    lines.push(`*${start + index + 1}.* ${name}`)
+    lines.push(`   » Mensajes: \`${user.messages}\`, Comandos: \`${user.commands}\``)
+  }
+
+  lines.push('')
+  if (safePage < totalPages) {
+    lines.push(`> Para ver la siguiente página › *${usedPrefix}topmensajes ${safePage + 1}*`)
+  } else if (totalPages > 1) {
+    lines.push(`> Para volver a la primera página › *${usedPrefix}topmensajes 1*`)
+  }
+  lines.push(`> Página *${safePage}/${totalPages}* · Total registrado: *${ranking.length}* miembros`)
+
+  await conn.sendMessage(m.chat, { text: lines.join('\n'), mentions: pageItems.map(user => user.jid) }, { quoted: m })
+}
+
+handler.help = ['topmensajes [página]', 'topmensajes [días] [página]']
+handler.tags = ['group']
+handler.command = ['topmensajes', 'topmsg', 'topmsgs', 'rankingmensajes', 'mensajesgrupo', 'topactividad', 'actividadgrupo']
+handler.group = true
+
+export default handler

--- a/plugins/main-menugrupo.js
+++ b/plugins/main-menugrupo.js
@@ -59,6 +59,8 @@ let handler = async (m, { conn }) => {
 > ✦ Elimina mensajes de otros usuarios.
 ᪄🧛🏼‍♀️᮫ᮣᮭᮡᩪᩬᩧᩦᩥ᪃ ؉ ᩡᩡ *#fantasmas*
 > ✦ Ver lista de inactivos del grupo.
+᪄🧛🏼‍♀️᮫ᮣᮭᮡᩪᩬᩧᩦᩥ᪃ ؉ ᩡᩡ *#topmensajes • #topmsg • #topactividad* [página]
+> ✦ Ver el ranking de mensajes y comandos de los últimos 30 días.
 ᪄🧛🏼‍♀️᮫ᮣᮭᮡᩪᩬᩧᩦᩥ᪃ ؉ ᩡᩡ *#kickfantasmas*
 > ✦ Elimina a los inactivos del grupo.
 ᪄🧛🏼‍♀️᮫ᮣᮭᮡᩪᩬᩧᩦᩥ᪃ ؉ ᩡᩡ *#invocar • #tagall • #todos*
@@ -86,7 +88,7 @@ let handler = async (m, { conn }) => {
         },
       },
     },
-    { quoted: fkontak }
+    { quoted: global.fkontak || m }
   );
 };
 


### PR DESCRIPTION
### Motivation
- Registrar la actividad de mensajes por miembro en grupos para poder consultar un ranking por periodos (ej. 30 días) y ordenar el menú del bot. 

### Description
- Añadido `plugins/_message-stats.js`, un recolector pasivo (`handler.before`) que guarda por usuario contadores diarios de `messages` y `commands`, mantiene nombres y limpia días antiguos (máx. 45 días). 
- Añadido `plugins/grupo-topmensajes.js`, comando de grupo `topmensajes` con aliases (`topmsg`, `topmsgs`, `rankingmensajes`, `mensajesgrupo`, `topactividad`, `actividadgrupo`), paginación (10 por página) y opción para ajustar días (por defecto 30, tope 45). 
- Actualizado `plugins/main-menugrupo.js` para anunciar `#topmensajes` en el menú y corregido fallback del mensaje citado para evitar uso de una variable local no definida (`{ quoted: global.fkontak || m }`). 
- Nueva lógica diseñada para filtrar solo miembros activos del grupo y usar `conn.getName` para mostrar nombres legibles en el ranking. 

### Testing
- Importación de las nuevas unidades con: `node -e "import('./plugins/_message-stats.js').then(()=>import('./plugins/grupo-topmensajes.js')).then(()=>import('./plugins/main-menugrupo.js')).then(()=>console.log('imports ok'))"` — resultó `imports ok`.
- Simulación de recolección y consulta con: `node --input-type=module` ejecutando el hook y el comando; la salida mostró el `Top de mensajes` esperado (ej. 2 mensajes, 1 comando) y fue verificada como correcta.
- Barrido de importación de todos los plugins con `node --input-type=module` para detectar errores de carga y compatibilidad — todos los plugins se importaron correctamente (414/414) y las nuevas plantillas no rompieron la carga.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1fc6925c833188c08d4c3935f29f)