### PR TITLE
perf: cache group metadata and compiled prefix regex to reduce message-loop work

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -7,6 +7,7 @@ import { unwatchFile, watchFile } from 'fs'
 import chalk from 'chalk'
 import fetch from 'node-fetch'
 import failureHandler from './lib/respuesta.js';
+import { TTLCache, getPrefixMatcherCache } from './lib/optimizer.js'
 const { proto } = (await import('@whiskeysockets/baileys')).default
 const isNumber = x => typeof x === 'number' && !isNaN(x)
 const delay = ms => isNumber(ms) && new Promise(resolve => setTimeout(function () {
@@ -14,9 +15,25 @@ clearTimeout(this)
 resolve()
 }, ms))
 global.uptimeStart = Date.now();
+
+const GROUP_METADATA_TTL = 60 * 1000
+const GROUP_METADATA_MAX = 2000
+function normalizeParticipant(participant = {}) {
+return { ...participant, id: participant.jid, jid: participant.jid, lid: participant.lid, admin: participant.admin || participant.isAdmin || participant.role }
+}
+async function getCachedGroupMetadata(conn, chatId) {
+conn.__groupMetadataCache = conn.__groupMetadataCache || new TTLCache(GROUP_METADATA_TTL, GROUP_METADATA_MAX)
+const cached = conn.__groupMetadataCache.get(chatId)
+if (cached) return cached
+const metadata = await conn.groupMetadata(chatId).catch(() => null) || {}
+if (Array.isArray(metadata.participants)) metadata.participants = metadata.participants.map(normalizeParticipant)
+conn.__groupMetadataCache.set(chatId, metadata)
+return metadata
+}
 export async function handler(chatUpdate) {
 this.msgqueque = this.msgqueque || []
 this.uptime = this.uptime || Date.now()
+if (this.__groupMetadataCache && Math.random() < 0.01) this.__groupMetadataCache.clearExpired()
 if (!chatUpdate) return
 let sender = null;
 try {
@@ -47,8 +64,8 @@ if (this?.user?.jid !== chat.primaryBot) return;
 }
 }
 sender = m.isGroup ? (m.key?.participant ? m.key.participant : m.sender) : m.key?.remoteJid;
-const groupMetadata = m.isGroup ? { ...(this.chats[m.chat]?.metadata || await this.groupMetadata(m.chat).catch(_ => null) || {}), ...(((this.chats[m.chat]?.metadata || await this.groupMetadata(m.chat).catch(_ => null) || {}).participants) && { participants: ((this.chats[m.chat]?.metadata || await this.groupMetadata(m.chat).catch(_ => null) || {}).participants || []).map(p => ({ ...p, id: p.jid, jid: p.jid, lid: p.lid, admin: p.admin || p.isAdmin || p.role })) }) } : {}
-const participants = ((m.isGroup ? groupMetadata.participants : []) || []).map(participant => ({ id: participant.jid, jid: participant.jid, lid: participant.lid, admin: participant.admin }))
+const groupMetadata = m.isGroup ? await getCachedGroupMetadata(this, m.chat) : {}
+const participants = Array.isArray(groupMetadata.participants) ? groupMetadata.participants : []
 if (m.isGroup) {
 if (sender && sender.endsWith('@lid')) {
 const pInfo = participants.find(p => p.lid === sender)
@@ -184,15 +201,29 @@ await plugin.all.call(this, m, { chatUpdate, __dirname: ___dirname, __filename }
 } catch (e) { console.error(e) }
 }
 if (!opts['restrict'] && plugin.tags && plugin.tags.includes('admin')) continue
-const str2Regex = str => str.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
+const str2Regex = str => str.replace(/[|\{}()[\]^$+*?.]/g, '\\$&')
+const prefixCache = getPrefixMatcherCache(this)
 let _prefix = plugin.customPrefix ? plugin.customPrefix : this.prefix ? this.prefix : global.prefix
 let match = (_prefix instanceof RegExp ? [[_prefix.exec(m.text), _prefix]] :
 Array.isArray(_prefix) ? _prefix.map(p => {
-let re = p instanceof RegExp ? p : new RegExp(str2Regex(p))
+const cacheKey = p instanceof RegExp ? `re:${p.source}:${p.flags}` : `str:${p}`
+let re = prefixCache.get(cacheKey)
+if (!re) {
+re = p instanceof RegExp ? p : new RegExp(str2Regex(p))
+prefixCache.set(cacheKey, re)
+}
 return [re.exec(m.text), re]
 }) :
-typeof _prefix === 'string' ? [[new RegExp(str2Regex(_prefix)).exec(m.text), new RegExp(str2Regex(_prefix))]] : [[[], new RegExp]]
-).find(p => p[1])
+typeof _prefix === 'string' ? (() => {
+const cacheKey = `str:${_prefix}`
+let re = prefixCache.get(cacheKey)
+if (!re) {
+re = new RegExp(str2Regex(_prefix))
+prefixCache.set(cacheKey, re)
+}
+return [[re.exec(m.text), re]]
+})() : [[[], new RegExp]])
+.find(p => p[1])
 if (typeof plugin.before === 'function') {
 if (await plugin.before.call(this, m, {
 match, conn: this, participants, groupMetadata, user: userGroup, bot: botGroup, isROwner, isOwner, isRAdmin, isAdmin, isBotAdmin, isPrems, chatUpdate, __dirname: ___dirname, __filename

--- a/lib/optimizer.js
+++ b/lib/optimizer.js
@@ -1,0 +1,41 @@
+export class TTLCache {
+  constructor(ttlMs = 30_000, maxSize = 500) {
+    this.ttlMs = ttlMs
+    this.maxSize = maxSize
+    this.store = new Map()
+  }
+
+  get(key) {
+    const entry = this.store.get(key)
+    if (!entry) return null
+    if (entry.expiresAt <= Date.now()) {
+      this.store.delete(key)
+      return null
+    }
+    return entry.value
+  }
+
+  set(key, value, ttlOverrideMs) {
+    if (this.store.size >= this.maxSize) {
+      const oldestKey = this.store.keys().next().value
+      if (oldestKey) this.store.delete(oldestKey)
+    }
+    this.store.set(key, {
+      value,
+      expiresAt: Date.now() + (ttlOverrideMs || this.ttlMs),
+    })
+    return value
+  }
+
+  clearExpired() {
+    const now = Date.now()
+    for (const [key, entry] of this.store.entries()) {
+      if (entry.expiresAt <= now) this.store.delete(key)
+    }
+  }
+}
+
+export function getPrefixMatcherCache(ctx) {
+  if (!ctx.__prefixMatcherCache) ctx.__prefixMatcherCache = new Map()
+  return ctx.__prefixMatcherCache
+}


### PR DESCRIPTION
### Motivation
- Reduce per-message CPU and network work that grows with number of sub-bots/groups by avoiding repeated `groupMetadata` calls and repeated RegExp compilation in the command pipeline.
- Improve responsiveness and long‑uptime stability by adding a small hot-path cache and opportunistic cleanup to prevent memory growth.

### Description
- Added a lightweight `TTLCache` and `getPrefixMatcherCache` in `lib/optimizer.js` to provide a simple expiring in-memory cache for hot data.
- Replaced the inline repeated `groupMetadata` retrieval in `handler.js` with `getCachedGroupMetadata(conn, chatId)` which caches metadata for `60s` and normalizes participants once per cache entry.
- Cached compiled prefix matchers per-context using `getPrefixMatcherCache(this)` to avoid reconstructing `RegExp` objects for each plugin/message iteration.
- Added opportunistic expired-entry cleanup in the handler to limit long‑term memory accumulation.

### Testing
- Checked syntax with `node --check handler.js` and `node --check lib/optimizer.js`, both succeeded.
- Verified that `nopasanada.zip` was inspected (archive listing) and repository state was observed during development (commands executed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a110375800c8331b14b3001f200a988)