### PR TITLE
Arreglar extracción directa de MP4 en hentaidl (veohentai)

### DIFF
--- a/lib/hentai.js
+++ b/lib/hentai.js
@@ -23,6 +23,15 @@ const decodeB64 = (str = '') => {
   }
 }
 
+const extractMp4Url = (content = '') => {
+  if (!content) return ''
+
+  const rawMp4 = content.match(/https?:\/\/[^"'\s]+\.mp4[^"'\s<]*/i)
+  if (rawMp4?.[0]) return rawMp4[0].replace(/&amp;/g, '&')
+
+  return ''
+}
+
 async function searchHentai(query) {
   const res = await fetch(`${BASE}/?s=${encodeURIComponent(query)}`, { headers: HEADERS })
   if (!res.ok) throw new Error(`Error de búsqueda: ${res.status}`)
@@ -52,26 +61,44 @@ async function getHentaiDetail(url) {
   const dislikes = $('#num-dislike').first().text().trim()
   const thumbnail = normalizeUrl($('meta[property="og:image"]').attr('content') || $('img').first().attr('src'))
 
-  const iframeSrc = normalizeUrl($('.aspect-w-16.aspect-h-9 iframe, iframe').first().attr('src'))
-  if (!iframeSrc) return { title, views, likes, dislikes, thumbnail, videoUrl: '' }
-
-  const iframeRes = await fetch(iframeSrc, { headers: { ...HEADERS, Referer: target } })
-  if (!iframeRes.ok) throw new Error(`Error en player: ${iframeRes.status}`)
-  const iframeHtml = await iframeRes.text()
-
-  const directMatch = iframeHtml.match(/data-id="\/player\.php\?u=([^&"\s]*)/i)
-  const fileMatch = iframeHtml.match(/["']file["']\s*:\s*["'](https?:\/\/[^"']+)["']/i)
   let videoUrl = ''
 
-  if (directMatch?.[1]) {
-    videoUrl = decodeB64(decodeURIComponent(directMatch[1]))
-  }
-  if (!videoUrl && fileMatch?.[1]) {
-    videoUrl = fileMatch[1]
-  }
+  // 1) Primero intentar el botón/link de descarga directo en la página principal.
+  $('a[href]').each((_, el) => {
+    if (videoUrl) return
+    const href = $(el).attr('href') || ''
+    const text = $(el).text().toLowerCase()
+    const looksLikeDownload = /descarg|download|bajar/.test(text) || /\.mp4(\?|$)/i.test(href)
+    if (!looksLikeDownload) return
+
+    const normalized = normalizeUrl(href)
+    if (/\.mp4(\?|$)/i.test(normalized)) videoUrl = normalized
+  })
+
+  // 2) Buscar cualquier URL mp4 incrustada en el HTML principal.
   if (!videoUrl) {
-    const rawMp4 = iframeHtml.match(/https?:\/\/[^"'\s]+\.mp4[^"'\s]*/i)
-    if (rawMp4?.[0]) videoUrl = rawMp4[0]
+    videoUrl = extractMp4Url(html)
+  }
+
+  // 3) Fallback: intentar extraer desde el iframe/player.
+  const iframeSrc = normalizeUrl($('.aspect-w-16.aspect-h-9 iframe, iframe').first().attr('src'))
+  if (!videoUrl && iframeSrc) {
+    const iframeRes = await fetch(iframeSrc, { headers: { ...HEADERS, Referer: target } })
+    if (!iframeRes.ok) throw new Error(`Error en player: ${iframeRes.status}`)
+    const iframeHtml = await iframeRes.text()
+
+    const directMatch = iframeHtml.match(/data-id="\/player\.php\?u=([^&"\s]*)/i)
+    const fileMatch = iframeHtml.match(/["']file["']\s*:\s*["'](https?:\/\/[^"']+)["']/i)
+
+    if (directMatch?.[1]) {
+      videoUrl = decodeB64(decodeURIComponent(directMatch[1]))
+    }
+    if (!videoUrl && fileMatch?.[1]) {
+      videoUrl = fileMatch[1]
+    }
+    if (!videoUrl) {
+      videoUrl = extractMp4Url(iframeHtml)
+    }
   }
 
   return { title, views, likes, dislikes, thumbnail, videoUrl }


### PR DESCRIPTION
### Motivation
- El objetivo es permitir que el comando de descarga de hentai encuentre y use enlaces MP4 directos presentes en la página de Veohentai en lugar de depender únicamente del iframe/player.
- Evitar falsos negativos donde el bot devolvía `No se encontró información del video` cuando la página sí ofrecía un enlace descargable (incluyendo URLs con query params tipo `?verify=`).

### Description
- Añadí el helper `extractMp4Url` en `lib/hentai.js` para detectar y normalizar URLs directas a `.mp4` (reemplaza `&amp;` por `&`).
- Modifiqué `getHentaiDetail` para priorizar: 1) escanear enlaces de la página por botones/hrefs de descarga y `.mp4`, 2) buscar MP4 incrustado en el HTML principal, y 3) mantener el fallback de extracción desde el `iframe`/player existente.
- La lógica de extracción del `iframe` (decodificar `data-id`, buscar `file:` y buscar MP4 crudo) se conserva como último recurso.
- No se tocaron las funciones de tamaño de archivo `getFileSize` ni la interfaz pública (`searchHentai`, `getHentaiDetail`, `getFileSize`).

### Testing
- Ejecuté `node -e "import('./lib/hentai.js')..."` para validar que `lib/hentai.js` se importa correctamente y la verificación de módulo fue exitosa.
- Intenté hacer una petición en tiempo real a `https://veohentai.com/...` desde el entorno de ejecución pero la resolución DNS falló (`getaddrinfo EAI_AGAIN`), por lo que no se pudo hacer una verificación end-to-end de descarga en este entorno.
- No se detectaron errores de sintaxis al importar el módulo después de los cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e63d122c8331b14b8a02d2745aad)