### PR TITLE
Improve MP4 extraction and add graceful fallback for VeoHentai downloads

### DIFF
--- a/lib/hentai.js
+++ b/lib/hentai.js
@@ -23,6 +23,32 @@ const decodeB64 = (str = '') => {
   }
 }
 
+const extractMp4Url = (content = '') => {
+  if (!content) return ''
+
+  const cleaned = content
+    .replace(/\\\//g, '/')
+    .replace(/\u0026/gi, '&')
+    .replace(/&amp;/g, '&')
+
+  const rawMp4 = cleaned.match(/https?:\/\/[^"'\s]+\.mp4[^"'\s<]*/i)
+  if (rawMp4?.[0]) return rawMp4[0].replace(/&amp;/g, '&')
+
+  return ''
+}
+
+const extractFromScripts = (html = '') => {
+  if (!html) return ''
+
+  const urlInWindowOpen = html.match(/(?:window\.open|location\.href)\((['"])(https?:\\\/\\\/[^"']+?\.mp4[^"']*)\1/i)
+  if (urlInWindowOpen?.[2]) return extractMp4Url(urlInWindowOpen[2])
+
+  const urlInJson = html.match(/(['"])(https?:\\\/\\\/[^"']+?\.mp4[^"']*)\1/i)
+  if (urlInJson?.[2]) return extractMp4Url(urlInJson[2])
+
+  return ''
+}
+
 async function searchHentai(query) {
   const res = await fetch(`${BASE}/?s=${encodeURIComponent(query)}`, { headers: HEADERS })
   if (!res.ok) throw new Error(`Error de búsqueda: ${res.status}`)
@@ -52,26 +78,52 @@ async function getHentaiDetail(url) {
   const dislikes = $('#num-dislike').first().text().trim()
   const thumbnail = normalizeUrl($('meta[property="og:image"]').attr('content') || $('img').first().attr('src'))
 
-  const iframeSrc = normalizeUrl($('.aspect-w-16.aspect-h-9 iframe, iframe').first().attr('src'))
-  if (!iframeSrc) return { title, views, likes, dislikes, thumbnail, videoUrl: '' }
-
-  const iframeRes = await fetch(iframeSrc, { headers: { ...HEADERS, Referer: target } })
-  if (!iframeRes.ok) throw new Error(`Error en player: ${iframeRes.status}`)
-  const iframeHtml = await iframeRes.text()
-
-  const directMatch = iframeHtml.match(/data-id="\/player\.php\?u=([^&"\s]*)/i)
-  const fileMatch = iframeHtml.match(/["']file["']\s*:\s*["'](https?:\/\/[^"']+)["']/i)
   let videoUrl = ''
 
-  if (directMatch?.[1]) {
-    videoUrl = decodeB64(decodeURIComponent(directMatch[1]))
-  }
-  if (!videoUrl && fileMatch?.[1]) {
-    videoUrl = fileMatch[1]
-  }
+  // 1) Primero intentar el botón/link de descarga directo en la página principal.
+  $('a[href]').each((_, el) => {
+    if (videoUrl) return
+    const href = $(el).attr('href') || ''
+    const text = $(el).text().toLowerCase()
+    const looksLikeDownload = /descarg|download|bajar/.test(text) || /\.mp4(\?|$)/i.test(href)
+    if (!looksLikeDownload) return
+
+    const normalized = normalizeUrl(href)
+    if (/\.mp4(\?|$)/i.test(normalized)) videoUrl = normalized
+  })
+
+  // 2) Buscar cualquier URL mp4 incrustada en el HTML principal.
   if (!videoUrl) {
-    const rawMp4 = iframeHtml.match(/https?:\/\/[^"'\s]+\.mp4[^"'\s]*/i)
-    if (rawMp4?.[0]) videoUrl = rawMp4[0]
+    videoUrl = extractMp4Url(html)
+  }
+
+  // 2.1) Algunas páginas guardan la URL MP4 escapada dentro de scripts.
+  if (!videoUrl) {
+    videoUrl = extractFromScripts(html)
+  }
+
+  // 3) Fallback: intentar extraer desde el iframe/player.
+  const iframeSrc = normalizeUrl($('.aspect-w-16.aspect-h-9 iframe, iframe').first().attr('src'))
+  if (!videoUrl && iframeSrc) {
+    const iframeRes = await fetch(iframeSrc, { headers: { ...HEADERS, Referer: target } })
+    if (!iframeRes.ok) throw new Error(`Error en player: ${iframeRes.status}`)
+    const iframeHtml = await iframeRes.text()
+
+    const directMatch = iframeHtml.match(/data-id="\/player\.php\?u=([^&"\s]*)/i)
+    const fileMatch = iframeHtml.match(/["']file["']\s*:\s*["'](https?:\/\/[^"']+)["']/i)
+
+    if (directMatch?.[1]) {
+      videoUrl = decodeB64(decodeURIComponent(directMatch[1]))
+    }
+    if (!videoUrl && fileMatch?.[1]) {
+      videoUrl = fileMatch[1]
+    }
+    if (!videoUrl) {
+      videoUrl = extractMp4Url(iframeHtml)
+    }
+    if (!videoUrl) {
+      videoUrl = extractFromScripts(iframeHtml)
+    }
   }
 
   return { title, views, likes, dislikes, thumbnail, videoUrl }

--- a/plugins/descargas-hentaidl.js
+++ b/plugins/descargas-hentaidl.js
@@ -14,7 +14,10 @@ let handler = async (m, { conn, text, usedPrefix, command }) => {
 
     if (text.includes('veohentai.com/ver/')) {
       const info = await getHentaiDetail(text)
-      if (!info?.videoUrl) return conn.reply(m.chat, '❌ No se encontró información del video.', m)
+      if (!info?.videoUrl) {
+        const fallbackTitle = info?.title || decodeURIComponent(text.split('/ver/')[1]?.replace(/\/+$/, '')?.replace(/-/g, ' ') || 'Sin título')
+        return conn.reply(m.chat, `❌ No pude extraer el enlace MP4 en este intento.\n\n• *Título:* ${fallbackTitle}\n• *Link:* ${text}\n\nIntenta de nuevo en unos segundos (los links con verify expiran rápido).`, m)
+      }
 
       const peso = await getFileSize(info.videoUrl)
       const cap = `╭─「 🔞 *HENTAI - DOWNLOAD* 」


### PR DESCRIPTION
### Motivation

- Make `getHentaiDetail` more resilient to different ways the MP4 URL is embedded or escaped in the page or player, and prefer direct download links present on the page. 
- Provide clearer user feedback when an MP4 URL cannot be extracted so callers know the title and original link and can retry.

### Description

- Added helper `extractMp4Url` to unescape common encodings and extract an `.mp4` URL from a string. 
- Added helper `extractFromScripts` to find MP4 URLs inside script fragments and `window.open`/`location.href` usages. 
- Reworked `getHentaiDetail` to (1) first scan page anchors for download hints, (2) try extracting any MP4 directly from the main HTML, (3) attempt script-based extraction, and (4) fall back to loading and parsing the iframe/player content when needed. 
- Updated `descargas-hentaidl.js` to return a helpful message with a fallback title and original link when no MP4 could be extracted instead of a generic error, and preserved the existing file-size and send flow when a URL is found.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e63d122c8331b14b8a02d2745aad)