### PR TITLE
Robust MP4 extraction for VeoHentai and add 3Hentai gallery downloader plugin

### DIFF
--- a/lib/hentai.js
+++ b/lib/hentai.js
@@ -23,6 +23,32 @@ const decodeB64 = (str = '') => {
   }
 }
 
+const extractMp4Url = (content = '') => {
+  if (!content) return ''
+
+  const cleaned = content
+    .replace(/\\\//g, '/')
+    .replace(/\u0026/gi, '&')
+    .replace(/&amp;/g, '&')
+
+  const rawMp4 = cleaned.match(/https?:\/\/[^"'\s]+\.mp4[^"'\s<]*/i)
+  if (rawMp4?.[0]) return rawMp4[0].replace(/&amp;/g, '&')
+
+  return ''
+}
+
+const extractFromScripts = (html = '') => {
+  if (!html) return ''
+
+  const urlInWindowOpen = html.match(/(?:window\.open|location\.href)\((['"])(https?:\\\/\\\/[^"']+?\.mp4[^"']*)\1/i)
+  if (urlInWindowOpen?.[2]) return extractMp4Url(urlInWindowOpen[2])
+
+  const urlInJson = html.match(/(['"])(https?:\\\/\\\/[^"']+?\.mp4[^"']*)\1/i)
+  if (urlInJson?.[2]) return extractMp4Url(urlInJson[2])
+
+  return ''
+}
+
 async function searchHentai(query) {
   const res = await fetch(`${BASE}/?s=${encodeURIComponent(query)}`, { headers: HEADERS })
   if (!res.ok) throw new Error(`Error de búsqueda: ${res.status}`)
@@ -52,26 +78,52 @@ async function getHentaiDetail(url) {
   const dislikes = $('#num-dislike').first().text().trim()
   const thumbnail = normalizeUrl($('meta[property="og:image"]').attr('content') || $('img').first().attr('src'))
 
-  const iframeSrc = normalizeUrl($('.aspect-w-16.aspect-h-9 iframe, iframe').first().attr('src'))
-  if (!iframeSrc) return { title, views, likes, dislikes, thumbnail, videoUrl: '' }
-
-  const iframeRes = await fetch(iframeSrc, { headers: { ...HEADERS, Referer: target } })
-  if (!iframeRes.ok) throw new Error(`Error en player: ${iframeRes.status}`)
-  const iframeHtml = await iframeRes.text()
-
-  const directMatch = iframeHtml.match(/data-id="\/player\.php\?u=([^&"\s]*)/i)
-  const fileMatch = iframeHtml.match(/["']file["']\s*:\s*["'](https?:\/\/[^"']+)["']/i)
   let videoUrl = ''
 
-  if (directMatch?.[1]) {
-    videoUrl = decodeB64(decodeURIComponent(directMatch[1]))
-  }
-  if (!videoUrl && fileMatch?.[1]) {
-    videoUrl = fileMatch[1]
-  }
+  // 1) Primero intentar el botón/link de descarga directo en la página principal.
+  $('a[href]').each((_, el) => {
+    if (videoUrl) return
+    const href = $(el).attr('href') || ''
+    const text = $(el).text().toLowerCase()
+    const looksLikeDownload = /descarg|download|bajar/.test(text) || /\.mp4(\?|$)/i.test(href)
+    if (!looksLikeDownload) return
+
+    const normalized = normalizeUrl(href)
+    if (/\.mp4(\?|$)/i.test(normalized)) videoUrl = normalized
+  })
+
+  // 2) Buscar cualquier URL mp4 incrustada en el HTML principal.
   if (!videoUrl) {
-    const rawMp4 = iframeHtml.match(/https?:\/\/[^"'\s]+\.mp4[^"'\s]*/i)
-    if (rawMp4?.[0]) videoUrl = rawMp4[0]
+    videoUrl = extractMp4Url(html)
+  }
+
+  // 2.1) Algunas páginas guardan la URL MP4 escapada dentro de scripts.
+  if (!videoUrl) {
+    videoUrl = extractFromScripts(html)
+  }
+
+  // 3) Fallback: intentar extraer desde el iframe/player.
+  const iframeSrc = normalizeUrl($('.aspect-w-16.aspect-h-9 iframe, iframe').first().attr('src'))
+  if (!videoUrl && iframeSrc) {
+    const iframeRes = await fetch(iframeSrc, { headers: { ...HEADERS, Referer: target } })
+    if (!iframeRes.ok) throw new Error(`Error en player: ${iframeRes.status}`)
+    const iframeHtml = await iframeRes.text()
+
+    const directMatch = iframeHtml.match(/data-id="\/player\.php\?u=([^&"\s]*)/i)
+    const fileMatch = iframeHtml.match(/["']file["']\s*:\s*["'](https?:\/\/[^"']+)["']/i)
+
+    if (directMatch?.[1]) {
+      videoUrl = decodeB64(decodeURIComponent(directMatch[1]))
+    }
+    if (!videoUrl && fileMatch?.[1]) {
+      videoUrl = fileMatch[1]
+    }
+    if (!videoUrl) {
+      videoUrl = extractMp4Url(iframeHtml)
+    }
+    if (!videoUrl) {
+      videoUrl = extractFromScripts(iframeHtml)
+    }
   }
 
   return { title, views, likes, dislikes, thumbnail, videoUrl }

--- a/lib/hentaimanga.js
+++ b/lib/hentaimanga.js
@@ -1,0 +1,53 @@
+import fetch from 'node-fetch'
+import cheerio from 'cheerio'
+
+const BASE = 'https://es.3hentai.net'
+const HEADERS = {
+  'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36',
+  Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+  'Accept-Language': 'es-ES,es;q=0.9,en;q=0.8'
+}
+
+const normalizeId = (text = '') => {
+  const byUrl = text.match(/3hentai\.net\/d\/(\d+)/i)
+  if (byUrl?.[1]) return byUrl[1]
+  const byDigits = text.trim().match(/^(\d+)$/)
+  if (byDigits?.[1]) return byDigits[1]
+  return ''
+}
+
+const normalizeImageLink = (url = '') => {
+  if (!url) return ''
+  return url.replace(/t\.(jpg|jpeg|png|webp)(\?.*)?$/i, '.$1$2')
+}
+
+async function get3HentaiGallery(input) {
+  const id = normalizeId(input)
+  if (!id) throw new Error('ID inválido. Usa un ID numérico o URL de /d/.')
+
+  const url = `${BASE}/d/${id}`
+  const res = await fetch(url, { headers: HEADERS })
+  if (!res.ok) throw new Error(`Error en 3hentai: ${res.status}`)
+
+  const html = await res.text()
+  const $ = cheerio.load(html)
+
+  const title = $('title').first().text().trim() || `3hentai-${id}`
+  const links = []
+
+  $('img[data-src], img[src]').each((_, el) => {
+    const src = $(el).attr('data-src') || $(el).attr('src') || ''
+    const full = src.startsWith('//') ? `https:${src}` : src
+    const normalized = normalizeImageLink(full)
+    if (/^https?:\/\//i.test(normalized) && /\.(jpg|jpeg|png|webp)(\?|$)/i.test(normalized)) {
+      links.push(normalized)
+    }
+  })
+
+  const images = [...new Set(links)]
+  if (!images.length) throw new Error('No se encontraron imágenes para descargar.')
+
+  return { id, title, url, images }
+}
+
+export { get3HentaiGallery, normalizeId }

--- a/plugins/descargas-3hentai.js
+++ b/plugins/descargas-3hentai.js
@@ -1,0 +1,50 @@
+import { get3HentaiGallery } from '../lib/hentaimanga.js'
+
+let handler = async (m, { conn, text, usedPrefix, command }) => {
+  if (!db.data.chats[m.chat].nsfw && m.isGroup) {
+    return m.reply(`${emoji} El contenido *NSFW* está desactivado en este grupo.\n> Un administrador puede activarlo con el comando » *#nsfw on*`)
+  }
+
+  if (!text) {
+    return conn.reply(m.chat, `🌱 Uso:\n• ${usedPrefix + command} 123456\n• ${usedPrefix + command} https://es.3hentai.net/d/123456`, m)
+  }
+
+  try {
+    await m.react('🕒')
+    const gallery = await get3HentaiGallery(text)
+
+    const maxImages = 25
+    const selected = gallery.images.slice(0, maxImages)
+
+    await conn.reply(
+      m.chat,
+      `🔞 *3Hentai descargador*\n` +
+        `• *Título:* ${gallery.title}\n` +
+        `• *ID:* ${gallery.id}\n` +
+        `• *Total imágenes:* ${gallery.images.length}\n` +
+        `• *Enviando:* ${selected.length}${gallery.images.length > maxImages ? ` (límite ${maxImages})` : ''}`,
+      m
+    )
+
+    for (let i = 0; i < selected.length; i++) {
+      const img = selected[i]
+      await conn.sendFile(m.chat, img, `page-${String(i + 1).padStart(3, '0')}.jpg`, `📄 Página ${i + 1}/${selected.length}`, m)
+    }
+
+    if (gallery.images.length > maxImages) {
+      await conn.reply(m.chat, `⚠️ Solo envié ${maxImages} páginas para evitar saturar el chat.`, m)
+    }
+
+    await m.react('✅')
+  } catch (e) {
+    console.error('Error 3hentai:', e)
+    await conn.reply(m.chat, `❌ Error al descargar desde 3hentai.\n\n${e.message}`, m)
+  }
+}
+
+handler.help = ['3hentai <id|url>']
+handler.tags = ['download', 'nsfw']
+handler.command = ['3hentai', 'h3dl', 'hentaimanga']
+handler.premium = true
+
+export default handler

--- a/plugins/descargas-hentaidl.js
+++ b/plugins/descargas-hentaidl.js
@@ -14,7 +14,10 @@ let handler = async (m, { conn, text, usedPrefix, command }) => {
 
     if (text.includes('veohentai.com/ver/')) {
       const info = await getHentaiDetail(text)
-      if (!info?.videoUrl) return conn.reply(m.chat, '❌ No se encontró información del video.', m)
+      if (!info?.videoUrl) {
+        const fallbackTitle = info?.title || decodeURIComponent(text.split('/ver/')[1]?.replace(/\/+$/, '')?.replace(/-/g, ' ') || 'Sin título')
+        return conn.reply(m.chat, `❌ No pude extraer el enlace MP4 en este intento.\n\n• *Título:* ${fallbackTitle}\n• *Link:* ${text}\n\nIntenta de nuevo en unos segundos (los links con verify expiran rápido).`, m)
+      }
 
       const peso = await getFileSize(info.videoUrl)
       const cap = `╭─「 🔞 *HENTAI - DOWNLOAD* 」


### PR DESCRIPTION
### Motivation
- Make video link extraction from VeoHentai pages more reliable by handling direct download links, escaped/encoded MP4 URLs and script-embedded URLs, and provide clearer fallback messaging when extraction fails.
- Add support for downloading galleries from 3Hentai (es.3hentai.net) as a new utility and command plugin.
- Prevent noisy failures in the Hentai downloader by improving extraction order and adding extra heuristics for links and iframes.

### Description
- Enhanced `lib/hentai.js` with `extractMp4Url` and `extractFromScripts` helpers and reworked `getHentaiDetail` to try (1) direct download links on page, (2) any MP4 in the main HTML, (3) script-embedded/escaped MP4s, and (4) iframe/player fallback including base64-decoded `data-id` handling; preserved existing decoding and HEADers behavior. 
- Added `lib/hentaimanga.js` implementing `get3HentaiGallery` and `normalizeId`/`normalizeImageLink` to fetch and normalize image lists from `es.3hentai.net` galleries. 
- Added plugin `plugins/descargas-3hentai.js` to expose a command (`3hentai`, `h3dl`, `hentaimanga`) that downloads up to 25 images from a 3Hentai gallery and respects NSFW group settings. 
- Updated `plugins/descargas-hentaidl.js` to handle missing `videoUrl` cases with a friendlier message and fallback title extraction, and to keep existing file-size, thumbnail and send-as-document behavior.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e63d122c8331b14b8a02d2745aad)