### PR TITLE
Reparar setmeta y sticker para metadata de stickers (CommonJS)

### DIFF
--- a/codigos-reparados/setmeta.js
+++ b/codigos-reparados/setmeta.js
@@ -1,0 +1,117 @@
+const fs = require('fs');
+const path = require('path');
+
+const META_FILE = path.join(process.cwd(), 'sticker_meta.json');
+
+function ensureUserMeta(sender) {
+    if (!global.db) global.db = { data: {} };
+    if (!global.db.data) global.db.data = {};
+    if (!global.db.data.users) global.db.data.users = {};
+    if (!global.db.data.users[sender]) global.db.data.users[sender] = {};
+    return global.db.data.users[sender];
+}
+
+async function saveMeta(sender, packname, author) {
+    const user = ensureUserMeta(sender);
+    user.text1 = packname;
+    user.text2 = author;
+
+    if (typeof global.db.write === 'function') {
+        await global.db.write();
+    }
+
+    // Respaldo para bots que no usan la base de datos global de Ruby Hoshino.
+    fs.writeFileSync(
+        META_FILE,
+        JSON.stringify({ packname, author, users: { [sender]: { packname, author } } }, null, 2),
+        'utf8'
+    );
+}
+
+module.exports = {
+    command: ['setmeta', 'delmeta'],
+    execute: async (m, { conn, from, args, command, usedPrefix }) => {
+        try {
+            const sender = m.sender || m.key?.participant || m.key?.remoteJid || from;
+            const texto = (args || []).join(' ').trim();
+            const cmd = (command || '').toLowerCase();
+
+            if (cmd === 'delmeta') {
+                const user = ensureUserMeta(sender);
+
+                if (!user.text1 && !user.text2 && !fs.existsSync(META_FILE)) {
+                    return conn.sendMessage(
+                        from,
+                        { text: '⚠️ No tienes metadatos personalizados guardados.' },
+                        { quoted: m }
+                    );
+                }
+
+                delete user.text1;
+                delete user.text2;
+
+                if (typeof global.db.write === 'function') {
+                    await global.db.write();
+                }
+
+                if (fs.existsSync(META_FILE)) fs.unlinkSync(META_FILE);
+
+                return conn.sendMessage(
+                    from,
+                    { text: '✅ Se restableció el pack y autor por defecto.' },
+                    { quoted: m }
+                );
+            }
+
+            if (!texto) {
+                const prefix = usedPrefix || '.';
+                return conn.sendMessage(
+                    from,
+                    {
+                        text:
+                            `⚠️ Uso: ${prefix}setmeta Nombre del Pack | Autor\n\n` +
+                            `Ejemplos:\n` +
+                            `• ${prefix}setmeta Ruby Hoshino | Dioneibi\n` +
+                            `• ${prefix}setmeta Solo Pack\n` +
+                            `• ${prefix}setmeta | Solo Autor`
+                    },
+                    { quoted: m }
+                );
+            }
+
+            const separator = /[|\u2022]/;
+            let packname = '';
+            let author = '';
+
+            if (separator.test(texto)) {
+                const [packInput = '', authorInput = ''] = texto.split(separator);
+                packname = packInput.trim();
+                author = authorInput.trim();
+            } else {
+                packname = texto;
+                author = '';
+            }
+
+            await saveMeta(sender, packname, author);
+
+            await conn.sendMessage(
+                from,
+                {
+                    text:
+                        `✅ Metadatos guardados correctamente.\n\n` +
+                        `📦 Pack: ${packname || '_Vacío_'}\n` +
+                        `✍️ Autor: ${author || '_Vacío_'}`
+                },
+                { quoted: m }
+            );
+        } catch (error) {
+            console.error('Error en setmeta:', error);
+
+            await conn.sendMessage(
+                from,
+                { text: '❌ Ocurrió un error al guardar los metadatos.' },
+                { quoted: m }
+            );
+        }
+    }
+};

--- a/codigos-reparados/sticker.js
+++ b/codigos-reparados/sticker.js
@@ -1,0 +1,152 @@
+const { execFile } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { promisify } = require('util');
+const { Sticker } = require('wa-sticker-formatter');
+const { downloadContentFromMessage } = require('@whiskeysockets/baileys');
+
+const execFileAsync = promisify(execFile);
+const META_FILE = path.join(process.cwd(), 'sticker_meta.json');
+
+function readSavedMeta(sender) {
+    const user = global.db?.data?.users?.[sender];
+
+    if (user && ('text1' in user || 'text2' in user)) {
+        return {
+            packname: user.text1 ?? '',
+            author: user.text2 ?? ''
+        };
+    }
+
+    if (fs.existsSync(META_FILE)) {
+        try {
+            const saved = JSON.parse(fs.readFileSync(META_FILE, 'utf8'));
+            const userSaved = saved.users?.[sender];
+            return {
+                packname: userSaved?.packname ?? saved.packname ?? global.packsticker ?? global.packname ?? '',
+                author: userSaved?.author ?? saved.author ?? global.packsticker2 ?? global.author ?? ''
+            };
+        } catch (error) {
+            console.error('No se pudo leer sticker_meta.json:', error);
+        }
+    }
+
+    return {
+        packname: global.packsticker ?? global.packname ?? '',
+        author: global.packsticker2 ?? global.author ?? ''
+    };
+}
+
+function getQuotedMessage(m) {
+    return m.quoted || m;
+}
+
+function getMediaMessage(q) {
+    return q.message?.imageMessage ||
+        q.message?.videoMessage ||
+        q.message?.stickerMessage ||
+        q.message?.extendedTextMessage?.contextInfo?.quotedMessage?.imageMessage ||
+        q.message?.extendedTextMessage?.contextInfo?.quotedMessage?.videoMessage ||
+        q.message?.extendedTextMessage?.contextInfo?.quotedMessage?.stickerMessage;
+}
+
+function getMediaType(q) {
+    if (q.message?.stickerMessage || q.message?.extendedTextMessage?.contextInfo?.quotedMessage?.stickerMessage) return 'sticker';
+    if (q.message?.videoMessage || q.message?.extendedTextMessage?.contextInfo?.quotedMessage?.videoMessage) return 'video';
+    return 'image';
+}
+
+async function streamToBuffer(stream) {
+    let buffer = Buffer.from([]);
+    for await (const chunk of stream) buffer = Buffer.concat([buffer, chunk]);
+    return buffer;
+}
+
+async function addStickerMeta(buffer, packname, author) {
+    const sticker = new Sticker(buffer, {
+        pack: packname,
+        author,
+        type: 'full',
+        quality: 80,
+        categories: ['🎀']
+    });
+
+    return sticker.toBuffer();
+}
+
+async function convertToWebp(input, output, isVideo) {
+    const videoArgs = isVideo
+        ? ['-t', '15', '-an', '-vsync', '0']
+        : ['-an'];
+
+    await execFileAsync('ffmpeg', [
+        '-y',
+        '-i', input,
+        ...videoArgs,
+        '-vf', 'scale=512:512:force_original_aspect_ratio=decrease,pad=512:512:(ow-iw)/2:(oh-ih)/2:color=black@0.0,fps=15',
+        '-c:v', 'libwebp',
+        '-preset', 'default',
+        '-loop', '0',
+        '-f', 'webp',
+        output
+    ]);
+}
+
+module.exports = {
+    command: ['s', 'sticker', 's2'],
+    execute: async (m, { conn, from, args }) => {
+        const q = getQuotedMessage(m);
+        const mediaMessage = getMediaMessage(q);
+
+        if (!mediaMessage) {
+            return conn.sendMessage(
+                from,
+                { text: '⚠️ Envía o responde a una imagen, video o sticker.' },
+                { quoted: m }
+            );
+        }
+
+        await conn.sendMessage(from, { react: { text: '⏳', key: m.key } });
+
+        const sender = m.sender || m.key?.participant || m.key?.remoteJid || from;
+        const savedMeta = readSavedMeta(sender);
+        const customMeta = (args || []).join(' ').trim();
+        const [packArg, authorArg] = customMeta
+            ? customMeta.split(/[|\u2022]/).map(value => value.trim())
+            : [];
+        const packname = customMeta ? (packArg ?? savedMeta.packname) : savedMeta.packname;
+        const author = customMeta && /[|\u2022]/.test(customMeta) ? (authorArg ?? '') : savedMeta.author;
+
+        const id = `${Date.now()}_${m.key?.id || Math.random().toString(16).slice(2)}`.replace(/[^a-zA-Z0-9_-]/g, '');
+        const input = path.join(os.tmpdir(), `sticker_${id}.bin`);
+        const output = path.join(os.tmpdir(), `sticker_${id}.webp`);
+
+        try {
+            const type = getMediaType(q);
+            const stream = await downloadContentFromMessage(mediaMessage, type);
+            const buffer = await streamToBuffer(stream);
+
+            let stickerBuffer;
+
+            if (type === 'sticker') {
+                // Importante: no se reenvía directo; se reescribe el EXIF para cambiar pack/autor.
+                stickerBuffer = await addStickerMeta(buffer, packname, author);
+            } else {
+                fs.writeFileSync(input, buffer);
+                await convertToWebp(input, output, type === 'video');
+                stickerBuffer = await addStickerMeta(fs.readFileSync(output), packname, author);
+            }
+
+            await conn.sendMessage(from, { sticker: stickerBuffer }, { quoted: m });
+            await conn.sendMessage(from, { react: { text: '✅', key: m.key } });
+        } catch (error) {
+            console.error('Error en sticker:', error);
+            await conn.sendMessage(from, { react: { text: '✖️', key: m.key } });
+            await conn.sendMessage(from, { text: `❌ Error: ${error.message || error}` }, { quoted: m });
+        } finally {
+            if (fs.existsSync(input)) fs.unlinkSync(input);
+            if (fs.existsSync(output)) fs.unlinkSync(output);
+        }
+    }
+};


### PR DESCRIPTION
### Motivation
- Arreglar que cambiar el texto/pack de los stickers no funcionaba al responder o crear stickers, manteniendo la compatibilidad con la estructura de Ruby Hoshino (`global.db.data.users[usuario].text1/text2`).
- Proveer una solución que funcione tanto para bots que usan `global.db.write()` como para instalaciones sin la DB de Ruby Hoshino mediante un respaldo JSON.

### Description
- Añadido `codigos-reparados/setmeta.js` que guarda `text1` y `text2` por usuario en `global.db.data.users[<sender>]` y además escribe un respaldo en `sticker_meta.json`, y soporta el comando `delmeta` para restaurar valores por defecto. 
- Añadido `codigos-reparados/sticker.js` que lee metadatos por usuario (con fallback al JSON y valores globales), permite override inline (`Pack | Autor`) y aplica esos metadatos al sticker.
- Al responder a un sticker ya no se reenvía tal cual; se reescribe el EXIF/metadata usando `wa-sticker-formatter` para que cambie pack/autor, y para imágenes/videos se convierte a WEBP usando `ffmpeg` en archivos temporales antes de añadir metadatos.
- Manejo de rutas temporales seguras, lectura/escritura robusta y tratamiento de errores con notificaciones al usuario; los archivos reparados están en `codigos-reparados/`.

### Testing
- Se ejecutó la verificación de sintaxis con `node --check codigos-reparados/setmeta.js && node --check codigos-reparados/sticker.js` y ambos archivos pasaron la comprobación.
- Se ejecutó la suite de comprobación principal con `npm test` y pasó sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21eb887c88832d86d9da537248706e)