### PR TITLE
Reestructura perfiles: elimina registro obligatorio, añade setname/setage, perfil actualizado y comando #ver

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -7,16 +7,16 @@ import { unwatchFile, watchFile } from 'fs'
 import chalk from 'chalk'
 import failureHandler from './lib/respuesta.js'
 import {
-  buildPermissionContext,
-  createParticipantIndex,
-  getCachedGroupMetadata,
-  commandMatches,
-  getPluginDirectory,
-  getPrefixMatch,
-  hydrateDatabaseForMessage,
-  isNumber,
-  normalizeLidReferences,
-  runMaintenance,
+buildPermissionContext,
+createParticipantIndex,
+getCachedGroupMetadata,
+commandMatches,
+getPluginDirectory,
+getPrefixMatch,
+hydrateDatabaseForMessage,
+isNumber,
+normalizeLidReferences,
+runMaintenance,
 } from './src/core/handler-utils.js'
 import { attachSessionState } from './src/core/session-manager.js'
 
@@ -27,281 +27,280 @@ const IGNORED_BAILEYS_IDS = [/^NJX-/, /^BAE5.{12}$/, /^B24E.{16}$/]
 const UNBAN_COMMAND_FILES = ['grupo-unbanchat.js']
 
 function getLatestMessage(chatUpdate) {
-  const messages = Array.isArray(chatUpdate?.messages) ? chatUpdate.messages : []
-  return messages.at(-1) || null
+const messages = Array.isArray(chatUpdate?.messages) ? chatUpdate.messages : []
+return messages.at(-1) || null
 }
 
 function isFreshMessage(message) {
-  const rawTimestamp = Number(message?.messageTimestamp || 0)
-  const messageTime = rawTimestamp > 0 ? rawTimestamp * 1000 : Date.now()
-  return Date.now() - messageTime <= SYSTEM_MESSAGE_MAX_AGE_MS
+const rawTimestamp = Number(message?.messageTimestamp || 0)
+const messageTime = rawTimestamp > 0 ? rawTimestamp * 1000 : Date.now()
+return Date.now() - messageTime <= SYSTEM_MESSAGE_MAX_AGE_MS
 }
 
 function shouldIgnoreBaileysId(id = '') {
-  return IGNORED_BAILEYS_IDS.some((pattern) => pattern.test(id))
+return IGNORED_BAILEYS_IDS.some((pattern) => pattern.test(id))
 }
 
 function parseCommand(text, usedPrefix) {
-  const noPrefix = text.replace(usedPrefix, '')
-  const parts = noPrefix.trim().split` `.filter(Boolean)
-  const [rawCommand, ...args] = parts
-  const _args = noPrefix.trim().split` `.slice(1)
-  return {
-    noPrefix,
-    args,
-    _args,
-    text: _args.join` `,
-    command: (rawCommand || '').toLowerCase(),
-  }
+const noPrefix = text.replace(usedPrefix, '')
+const parts = noPrefix.trim().split` `.filter(Boolean)
+const [rawCommand, ...args] = parts
+const _args = noPrefix.trim().split` `.slice(1)
+return {
+noPrefix,
+args,
+_args,
+text: _args.join` `,
+command: (rawCommand || '').toLowerCase(),
+}
 }
 
 function ensureQueue(conn, m, opts, isMods, isPrems) {
-  if (!opts?.queque || !m?.text || isMods || isPrems) return
-  const queue = conn.msgqueque ||= []
-  const previousID = queue.at(-1)
-  queue.push(m.id || m.key?.id)
-  setTimeout(() => {
-    const idx = queue.indexOf(previousID)
-    if (idx !== -1) queue.splice(idx, 1)
-  }, 5000)
+if (!opts?.queque || !m?.text || isMods || isPrems) return
+const queue = conn.msgqueque ||= []
+const previousID = queue.at(-1)
+queue.push(m.id || m.key?.id)
+setTimeout(() => {
+const idx = queue.indexOf(previousID)
+if (idx !== -1) queue.splice(idx, 1)
+}, 5000)
 }
 
 async function runPluginHooks(conn, plugin, name, m, context) {
-  if (typeof plugin?.all === 'function') {
-    try {
-      await plugin.all.call(conn, m, context)
-    } catch (error) {
-      console.error(error)
-    }
-  }
+if (typeof plugin?.all === 'function') {
+try {
+await plugin.all.call(conn, m, context)
+} catch (error) {
+console.error(error)
+}
+}
 }
 
 function sanitizeError(error) {
-  let text = format(error)
-  for (const key of Object.values(global.APIKeys || {})) text = text.replace(new RegExp(key, 'g'), 'Administrador')
-  return text
+let text = format(error)
+for (const key of Object.values(global.APIKeys || {})) text = text.replace(new RegExp(key, 'g'), 'Administrador')
+return text
 }
 
 async function executePlugin(conn, plugin, name, m, extra, permissionContext, sender) {
-  const { isROwner, isOwner, isMods, isPrems, isAdmin, isBotAdmin } = permissionContext
-  const fail = plugin.fail || global.dfail
-  const chat = global.db?.data?.chats?.[m.chat]
-  const user = global.db?.data?.users?.[sender]
+const { isROwner, isOwner, isMods, isPrems, isAdmin, isBotAdmin } = permissionContext
+const fail = plugin.fail || global.dfail
+const chat = global.db?.data?.chats?.[m.chat]
+const user = global.db?.data?.users?.[sender]
 
-  if (!UNBAN_COMMAND_FILES.includes(name) && chat?.isBanned && !isROwner) return true
-  if (m.text && user?.banned && !isROwner) {
-    if (!user.lastBanMsg || Date.now() - user.lastBanMsg > 30_000) {
-      m.reply(`《✦》Estas baneado/a, no puedes usar comandos en este bot!\n\n${user.bannedReason ? `✰ *Motivo:* ${user.bannedReason}` : '✰ *Motivo:* Sin Especificar'}\n\n> ✧ Si este Bot es cuenta ...`)
-      user.lastBanMsg = Date.now()
-    }
-    return true
-  }
-  if (user?.antispam && !user.banned) user.antispam = 0
+if (!UNBAN_COMMAND_FILES.includes(name) && chat?.isBanned && !isROwner) return true
+if (m.text && user?.banned && !isROwner) {
+if (!user.lastBanMsg || Date.now() - user.lastBanMsg > 30_000) {
+m.reply(`《✦》Estas baneado/a, no puedes usar comandos en este bot!\n\n${user.bannedReason ? `✰ *Motivo:* ${user.bannedReason}` : '✰ *Motivo:* Sin Especificar'}\n\n> ✧ Si este Bot es cuenta ...`)
+user.lastBanMsg = Date.now()
+}
+return true
+}
+if (user?.antispam && !user.banned) user.antispam = 0
 
-  const adminMode = chat?.modoadmin
-  if (adminMode && m.isGroup && !isAdmin && !isOwner && !isROwner) return true
-  if (plugin.botAdmin && !isBotAdmin) { fail('botAdmin', m, conn); return false }
-  if (plugin.rowner && plugin.owner && !(isROwner || isOwner)) { fail('owner', m, conn); return false }
-  if (plugin.rowner && !isROwner) { fail('rowner', m, conn); return false }
-  if (plugin.owner && !isOwner) { fail('owner', m, conn); return false }
-  if (plugin.mods && !isMods) { fail('mods', m, conn); return false }
-  if (plugin.premium && !isPrems) { fail('premium', m, conn); return false }
-  if (plugin.admin && !isAdmin) { fail('admin', m, conn); return false }
-  if (plugin.private && m.isGroup) { fail('private', m, conn); return false }
-  if (plugin.group && !m.isGroup) { fail('group', m, conn); return false }
-  if (plugin.register === true && user?.registered === false) { fail('unreg', m, conn); return false }
+const adminMode = chat?.modoadmin
+if (adminMode && m.isGroup && !isAdmin && !isOwner && !isROwner) return true
+if (plugin.botAdmin && !isBotAdmin) { fail('botAdmin', m, conn); return false }
+if (plugin.rowner && plugin.owner && !(isROwner || isOwner)) { fail('owner', m, conn); return false }
+if (plugin.rowner && !isROwner) { fail('rowner', m, conn); return false }
+if (plugin.owner && !isOwner) { fail('owner', m, conn); return false }
+if (plugin.mods && !isMods) { fail('mods', m, conn); return false }
+if (plugin.premium && !isPrems) { fail('premium', m, conn); return false }
+if (plugin.admin && !isAdmin) { fail('admin', m, conn); return false }
+if (plugin.private && m.isGroup) { fail('private', m, conn); return false }
+if (plugin.group && !m.isGroup) { fail('group', m, conn); return false }
 
-  m.isCommand = true
-  const xp = 'exp' in plugin ? parseInt(plugin.exp) : 17
-  if (xp > 200) m.reply('chirrido -_-')
-  else m.exp += xp
+m.isCommand = true
+const xp = 'exp' in plugin ? parseInt(plugin.exp) : 17
+if (xp > 200) m.reply('chirrido -_-')
+else m.exp += xp
 
-  if (!isPrems && plugin.coin && (global.db?.data?.users?.[sender]?.coin || 0) < plugin.coin * 1) {
-    conn.reply(m.chat, `❮✦❯ Se agotaron tus ${m.moneda}`, m)
-    return false
-  }
-  if (plugin.level > (user?.level || 0)) {
-    conn.reply(m.chat, `❮✦❯ Se requiere el nivel: *${plugin.level}*\n\n• Tu nivel actual es: *${user?.level || 0}*\n\n• Usa este comando para subir de nivel:\n*${extra.usedPrefix}levelup*`, m)
-    return false
-  }
+if (!isPrems && plugin.coin && (global.db?.data?.users?.[sender]?.coin || 0) < plugin.coin * 1) {
+conn.reply(m.chat, `❮✦❯ Se agotaron tus ${m.moneda}`, m)
+return false
+}
+if (plugin.level > (user?.level || 0)) {
+conn.reply(m.chat, `❮✦❯ Se requiere el nivel: *${plugin.level}*\n\n• Tu nivel actual es: *${user?.level || 0}*\n\n• Usa este comando para subir de nivel:\n*${extra.usedPrefix}levelup*`, m)
+return false
+}
 
-  try {
-    await plugin.call(conn, m, extra)
-    if (!isPrems) m.coin = m.coin || plugin.coin || false
-  } catch (error) {
-    m.error = error
-    console.error(error)
-    if (error) m.reply(sanitizeError(error))
-  } finally {
-    if (typeof plugin.after === 'function') {
-      try {
-        await plugin.after.call(conn, m, extra)
-      } catch (error) {
-        console.error(error)
-      }
-    }
-    if (m.coin) conn.reply(m.chat, `❮✦❯ Utilizaste ${+m.coin} ${m.moneda}`, m)
-  }
-  return true
+try {
+await plugin.call(conn, m, extra)
+if (!isPrems) m.coin = m.coin || plugin.coin || false
+} catch (error) {
+m.error = error
+console.error(error)
+if (error) m.reply(sanitizeError(error))
+} finally {
+if (typeof plugin.after === 'function') {
+try {
+await plugin.after.call(conn, m, extra)
+} catch (error) {
+console.error(error)
+}
+}
+if (m.coin) conn.reply(m.chat, `❮✦❯ Utilizaste ${+m.coin} ${m.moneda}`, m)
+}
+return true
 }
 
 function isUserMutedInChat(user, chatId) {
-  if (!user || !chatId) return false
-  if (user.mutedChats?.[chatId] === true) return true
-  return user.muto === true && (!user.mutoChat || user.mutoChat === chatId)
+if (!user || !chatId) return false
+if (user.mutedChats?.[chatId] === true) return true
+return user.muto === true && (!user.mutoChat || user.mutoChat === chatId)
 }
 
 function getMessageDeletePayload(m, sender) {
-  const key = m?.__deleteKey || m?.key || {}
-  const id = key.id || m?.id
-  const remoteJid = key.remoteJid || m?.chat
-  if (!id || !remoteJid) return null
-  const payload = { remoteJid, fromMe: Boolean(key.fromMe), id }
-  const participant = key.participant || m?.participant || sender
-  if (m?.isGroup && participant) payload.participant = participant
-  return payload
+const key = m?.__deleteKey || m?.key || {}
+const id = key.id || m?.id
+const remoteJid = key.remoteJid || m?.chat
+if (!id || !remoteJid) return null
+const payload = { remoteJid, fromMe: Boolean(key.fromMe), id }
+const participant = key.participant || m?.participant || sender
+if (m?.isGroup && participant) payload.participant = participant
+return payload
 }
 
 function updateStatsAndEconomy(conn, m, sender) {
-  const data = global.db?.data
-  if (!data || !m) return
-  const mutedUser = data.users?.[sender]
-  if (m.isGroup && isUserMutedInChat(mutedUser, m.chat)) {
-    const deletePayload = getMessageDeletePayload(m, sender)
-    if (deletePayload) conn.sendMessage?.(m.chat, { delete: deletePayload }).catch(() => {})
-  }
-  if (sender && data.users?.[sender]) {
-    data.users[sender].exp += m.exp || 0
-    data.users[sender].coin -= (m.coin || 0) * 1
-  }
-  if (!m.plugin) return
-  const stats = data.stats ||= {}
-  const now = Date.now()
-  const stat = stats[m.plugin] ||= { total: 0, success: 0, last: now, lastSuccess: 0 }
-  if (!isNumber(stat.total)) stat.total = 0
-  if (!isNumber(stat.success)) stat.success = 0
-  if (!isNumber(stat.last)) stat.last = now
-  if (!isNumber(stat.lastSuccess)) stat.lastSuccess = 0
-  stat.total += 1
-  stat.last = now
-  if (m.error == null) {
-    stat.success += 1
-    stat.lastSuccess = now
-  }
+const data = global.db?.data
+if (!data || !m) return
+const mutedUser = data.users?.[sender]
+if (m.isGroup && isUserMutedInChat(mutedUser, m.chat)) {
+const deletePayload = getMessageDeletePayload(m, sender)
+if (deletePayload) conn.sendMessage?.(m.chat, { delete: deletePayload }).catch(() => {})
+}
+if (sender && data.users?.[sender]) {
+data.users[sender].exp += m.exp || 0
+data.users[sender].coin -= (m.coin || 0) * 1
+}
+if (!m.plugin) return
+const stats = data.stats ||= {}
+const now = Date.now()
+const stat = stats[m.plugin] ||= { total: 0, success: 0, last: now, lastSuccess: 0 }
+if (!isNumber(stat.total)) stat.total = 0
+if (!isNumber(stat.success)) stat.success = 0
+if (!isNumber(stat.last)) stat.last = now
+if (!isNumber(stat.lastSuccess)) stat.lastSuccess = 0
+stat.total += 1
+stat.last = now
+if (m.error == null) {
+stat.success += 1
+stat.lastSuccess = now
+}
 }
 
 export async function handler(chatUpdate) {
-  attachSessionState(this)
-  runMaintenance(this)
-  const rawMessage = getLatestMessage(chatUpdate)
-  if (!rawMessage || !isFreshMessage(rawMessage)) return
+attachSessionState(this)
+runMaintenance(this)
+const rawMessage = getLatestMessage(chatUpdate)
+if (!rawMessage || !isFreshMessage(rawMessage)) return
 
-  this.pushMessage?.(chatUpdate?.messages || []).catch(console.error)
-  if (global.db && global.db.data == null) await global.loadDatabase?.()
+this.pushMessage?.(chatUpdate?.messages || []).catch(console.error)
+if (global.db && global.db.data == null) await global.loadDatabase?.()
 
-  let m = null
-  let sender = null
-  try {
-    m = smsg(this, rawMessage) || rawMessage
-    if (!m) return
-    const opts = this.opts || global.opts || {}
-    if (typeof m.text !== 'string') m.text = ''
+let m = null
+let sender = null
+try {
+m = smsg(this, rawMessage) || rawMessage
+if (!m) return
+const opts = this.opts || global.opts || {}
+if (typeof m.text !== 'string') m.text = ''
 
-    if (m.isGroup) {
-      const chat = global.db?.data?.chats?.[m.chat]
-      const primaryBot = chat?.primaryBot || chat?.botPrimario
-      if (primaryBot) {
-        const universalWords = ['resetbot', 'resetprimario', 'botreset']
-        const firstWord = m.text.trim().split(' ')[0]?.toLowerCase().replace(/^[./#]/, '') || ''
-        if (!universalWords.includes(firstWord) && this?.user?.jid !== primaryBot) return
-      }
-    }
+if (m.isGroup) {
+const chat = global.db?.data?.chats?.[m.chat]
+const primaryBot = chat?.primaryBot || chat?.botPrimario
+if (primaryBot) {
+const universalWords = ['resetbot', 'resetprimario', 'botreset']
+const firstWord = m.text.trim().split(' ')[0]?.toLowerCase().replace(/^[./#]/, '') || ''
+if (!universalWords.includes(firstWord) && this?.user?.jid !== primaryBot) return
+}
+}
 
-    sender = m.isGroup ? (m.key?.participant || m.sender) : (m.key?.remoteJid || m.sender)
-    if (!sender) return
-    m.__deleteKey = m.key ? { ...m.key } : null
-    const groupMetadata = m.isGroup ? await getCachedGroupMetadata(this, m.chat) : {}
-    const participants = Array.isArray(groupMetadata?.participants) ? groupMetadata.participants : []
-    sender = normalizeLidReferences(m, sender, m.isGroup ? createParticipantIndex(participants) : null)
+sender = m.isGroup ? (m.key?.participant || m.sender) : (m.key?.remoteJid || m.sender)
+if (!sender) return
+m.__deleteKey = m.key ? { ...m.key } : null
+const groupMetadata = m.isGroup ? await getCachedGroupMetadata(this, m.chat) : {}
+const participants = Array.isArray(groupMetadata?.participants) ? groupMetadata.participants : []
+sender = normalizeLidReferences(m, sender, m.isGroup ? createParticipantIndex(participants) : null)
 
-    m.exp = 0
-    m.coin = false
-    const { user: _user, settings } = hydrateDatabaseForMessage(this, m, sender)
+m.exp = 0
+m.coin = false
+const { user: _user, settings } = hydrateDatabaseForMessage(this, m, sender)
 
-    if (opts.nyimak) return
-    if (!m.fromMe && opts.self) return
-    if (opts.swonly && m.chat !== 'status@broadcast') return
+if (opts.nyimak) return
+if (!m.fromMe && opts.self) return
+if (opts.swonly && m.chat !== 'status@broadcast') return
 
-    const permissionContext = buildPermissionContext(this, m, sender, participants)
-    const { userGroup, botGroup, isRAdmin, isAdmin, isBotAdmin, isROwner, isOwner, isMods, isPrems } = permissionContext
-    m.moneda = settings?.moneda || 'Coins'
-    ensureQueue(this, m, opts, isMods, isPrems)
-    m.exp += Math.ceil(Math.random() * 10)
+const permissionContext = buildPermissionContext(this, m, sender, participants)
+const { userGroup, botGroup, isRAdmin, isAdmin, isBotAdmin, isROwner, isOwner, isMods, isPrems } = permissionContext
+m.moneda = settings?.moneda || 'Coins'
+ensureQueue(this, m, opts, isMods, isPrems)
+m.exp += Math.ceil(Math.random() * 10)
 
-    const pluginDir = getPluginDirectory()
-    for (const name in (global.plugins || {})) {
-      const plugin = global.plugins[name]
-      if (!plugin || plugin.disabled) continue
-      const __filename = join(pluginDir, name)
-      const baseContext = { chatUpdate, __dirname: pluginDir, __filename }
-      await runPluginHooks(this, plugin, name, m, baseContext)
-      if (!opts.restrict && plugin.tags?.includes?.('admin')) continue
+const pluginDir = getPluginDirectory()
+for (const name in (global.plugins || {})) {
+const plugin = global.plugins[name]
+if (!plugin || plugin.disabled) continue
+const __filename = join(pluginDir, name)
+const baseContext = { chatUpdate, __dirname: pluginDir, __filename }
+await runPluginHooks(this, plugin, name, m, baseContext)
+if (!opts.restrict && plugin.tags?.includes?.('admin')) continue
 
-      const match = getPrefixMatch(this, plugin, m.text)
-      const beforeContext = { match, conn: this, participants, groupMetadata, user: userGroup, bot: botGroup, isROwner, isOwner, isRAdmin, isAdmin, isBotAdmin, isPrems, chatUpdate, __dirname: pluginDir, __filename }
-      if (typeof plugin.before === 'function') {
-        if (await plugin.before.call(this, m, beforeContext)) continue
-      }
-      if (typeof plugin !== 'function' || !match?.[0]?.[0]) continue
+const match = getPrefixMatch(this, plugin, m.text)
+const beforeContext = { match, conn: this, participants, groupMetadata, user: userGroup, bot: botGroup, isROwner, isOwner, isRAdmin, isAdmin, isBotAdmin, isPrems, chatUpdate, __dirname: pluginDir, __filename }
+if (typeof plugin.before === 'function') {
+if (await plugin.before.call(this, m, beforeContext)) continue
+}
+if (typeof plugin !== 'function' || !match?.[0]?.[0]) continue
 
-      const usedPrefix = match[0][0]
-      const parsed = parseCommand(m.text, usedPrefix)
-      const isAccept = commandMatches(plugin.command, parsed.command)
-      global.comando = parsed.command
-      if (shouldIgnoreBaileysId(m.id || m.key?.id || '')) return
-      if (!isAccept) continue
+const usedPrefix = match[0][0]
+const parsed = parseCommand(m.text, usedPrefix)
+const isAccept = commandMatches(plugin.command, parsed.command)
+global.comando = parsed.command
+if (shouldIgnoreBaileysId(m.id || m.key?.id || '')) return
+if (!isAccept) continue
 
-      m.plugin = name
-      const chatData = global.db?.data?.chats?.[m.chat] || {}
-      const isBotBannedInThisChat = Array.isArray(chatData.bannedBots) && chatData.bannedBots.includes(this.user?.jid)
-      if (isBotBannedInThisChat && !UNBAN_COMMAND_FILES.includes(name)) return
+m.plugin = name
+const chatData = global.db?.data?.chats?.[m.chat] || {}
+const isBotBannedInThisChat = Array.isArray(chatData.bannedBots) && chatData.bannedBots.includes(this.user?.jid)
+if (isBotBannedInThisChat && !UNBAN_COMMAND_FILES.includes(name)) return
 
-      const extra = { match, usedPrefix, ...parsed, conn: this, participants, groupMetadata, user: userGroup, bot: botGroup, isROwner, isOwner, isRAdmin, isAdmin, isBotAdmin, isPrems, chatUpdate, __dirname: pluginDir, __filename }
-      await executePlugin(this, plugin, name, m, extra, permissionContext, sender)
-      break
-    }
-  } catch (error) {
-    console.error(error)
-  } finally {
-    try {
-      if (this.msgqueque && (this.opts || global.opts || {}).queque && m?.text) {
-        const queueIndex = this.msgqueque.indexOf(m.id || m.key?.id)
-        if (queueIndex !== -1) this.msgqueque.splice(queueIndex, 1)
-      }
-    } catch {}
-    try {
-      updateStatsAndEconomy(this, m, sender)
-    } catch (error) {
-      console.error(error)
-    }
-    try {
-      if (!((this.opts || global.opts || {}).noprint) && m) await (await import('./lib/print.js')).default(m, this)
-    } catch (error) {
-      console.log(chalk.red('Error en print.js'), error)
-    }
-  }
+const extra = { match, usedPrefix, ...parsed, conn: this, participants, groupMetadata, user: userGroup, bot: botGroup, isROwner, isOwner, isRAdmin, isAdmin, isBotAdmin, isPrems, chatUpdate, __dirname: pluginDir, __filename }
+await executePlugin(this, plugin, name, m, extra, permissionContext, sender)
+break
+}
+} catch (error) {
+console.error(error)
+} finally {
+try {
+if (this.msgqueque && (this.opts || global.opts || {}).queque && m?.text) {
+const queueIndex = this.msgqueque.indexOf(m.id || m.key?.id)
+if (queueIndex !== -1) this.msgqueque.splice(queueIndex, 1)
+}
+} catch {}
+try {
+updateStatsAndEconomy(this, m, sender)
+} catch (error) {
+console.error(error)
+}
+try {
+if (!((this.opts || global.opts || {}).noprint) && m) await (await import('./lib/print.js')).default(m, this)
+} catch (error) {
+console.log(chalk.red('Error en print.js'), error)
+}
+}
 }
 
 global.dfail = (type, m, conn) => { failureHandler(type, conn, m) }
 
 const file = typeof global.__filename === 'function' ? global.__filename(import.meta.url, true) : fileURLToPath(import.meta.url)
 watchFile(file, async () => {
-  unwatchFile(file)
-  console.log(chalk.green('Actualizando "handler.js"'))
-  if (global.conns?.length > 0) {
-    const users = [...new Set(global.conns.filter((conn) => conn.user && conn.ws?.socket && conn.ws.socket.readyState !== ws.CLOSED))]
-    for (const userr of users) {
-      try { userr.subreloadHandler(false) } catch {}
-    }
-  }
+unwatchFile(file)
+console.log(chalk.green('Actualizando "handler.js"'))
+if (global.conns?.length > 0) {
+const users = [...new Set(global.conns.filter((conn) => conn.user && conn.ws?.socket && conn.ws.socket.readyState !== ws.CLOSED))]
+for (const userr of users) {
+try { userr.subreloadHandler(false) } catch {}
+}
+}
 })

--- a/plugins/cmd-ver.js
+++ b/plugins/cmd-ver.js
@@ -1,0 +1,15 @@
+const handler=async(m,{conn,usedPrefix,command})=>{
+const quoted=m.quoted
+if(!quoted)return m.reply(`Responde a una imagen o video de una sola vista con *${usedPrefix+command}*.`)
+const mediaType=quoted.mediaType||quoted.mtype
+if(!['imageMessage','videoMessage'].includes(mediaType))return m.reply('El mensaje respondido no es una imagen o video compatible.')
+const media=await quoted.download()
+if(!media)return m.reply('No pude descargar el contenido. Intenta responder directamente al mensaje de una sola vista.')
+const caption=quoted.caption||quoted.text||''
+const payload=mediaType==='imageMessage'?{image:media,caption}:{video:media,caption}
+await conn.sendMessage(m.chat,payload,{quoted:m})
+}
+handler.help=['ver','readviewonce','read']
+handler.tags=['tools']
+handler.command=['ver','readviewonce','read']
+export default handler

--- a/plugins/main-menu.js
+++ b/plugins/main-menu.js
@@ -6,53 +6,53 @@ import path from 'path';
 const cwd = process.cwd();
 
 let handler = async (m, { conn, args }) => {
-  let userId = m.mentionedJid && m.mentionedJid[0] ? m.mentionedJid[0] : m.sender;
+let userId = m.mentionedJid && m.mentionedJid[0] ? m.mentionedJid[0] : m.sender;
 
 
-  let name = await conn.getName(userId);
+let name = await conn.getName(userId);
 
-  let user = global.db.data.users[userId];
-  let exp = user.exp || 0;
-  let level = user.level || 0;
-  let role = user.role || 'Sin Rango';
-  let coins = user.coin || 0;
+let user = global.db.data.users[userId];
+let exp = user.exp || 0;
+let level = user.level || 0;
+let role = user.role || 'Sin Rango';
+let coins = user.coin || 0;
 
-  let _uptime = process.uptime() * 1000;
-  let uptime = clockString(_uptime);
-  let totalreg = Object.keys(global.db.data.users).length;
-  let totalCommands = Object.values(global.plugins).filter(v => v.help && v.tags).length;
+let _uptime = process.uptime() * 1000;
+let uptime = clockString(_uptime);
+let totalreg = Object.keys(global.db.data.users).length;
+let totalCommands = Object.values(global.plugins).filter(v => v.help && v.tags).length;
 
-  const gifVideosDir = path.join(cwd, 'src', 'menu');
-  if (!fs.existsSync(gifVideosDir)) {
-    console.error('El directorio no existe:', gifVideosDir);
-    return;
-  }
+const gifVideosDir = path.join(cwd, 'src', 'menu');
+if (!fs.existsSync(gifVideosDir)) {
+console.error('El directorio no existe:', gifVideosDir);
+return;
+}
 
-  const gifVideos = fs.readdirSync(gifVideosDir)
-    .filter(file => file.endsWith('.mp4'))
-    .map(file => path.join(gifVideosDir, file));
+const gifVideos = fs.readdirSync(gifVideosDir)
+.filter(file => file.endsWith('.mp4'))
+.map(file => path.join(gifVideosDir, file));
 
-  const randomGif = gifVideos[Math.floor(Math.random() * gifVideos.length)];
+const randomGif = gifVideos[Math.floor(Math.random() * gifVideos.length)];
 
-  let txt = `
+let txt = `
 ୨୧‿̥̣‿̣̥̣̇‿̥̣୨୧‿̥̣‿̣̥̣̇‿̥̣୨୧‿̥̣‿̣̥̣̇‿̥̣୨୧୧‿̥̣‿̣̥̣̇‿̥̣୨୧
 ᰔ🩵𝙃𝙤𝙡𝙖! ${name} 𝙈𝙞 𝙣𝙤𝙢𝙗𝙧𝙚 𝙚𝙨 *Ruby Hoshino* ¡𝙀𝙨𝙥𝙚𝙧𝙤 𝙦𝙪𝙚 𝙚𝙨𝙩𝙚𝙨 𝙗𝙞𝙚𝙣! ໒꒰ྀི⁄ ⁄>⁄ ⁄ <⁄ ⁄꒱ྀི১
 
 ╔═══════⩽✦✰✦⩾═══════╗
-       「 𝙄𝙉𝙁𝙊 𝘿𝙀 𝙇𝘼 𝘽𝙊𝙏 」
+「 𝙄𝙉𝙁𝙊 𝘿𝙀 𝙇𝘼 𝘽𝙊𝙏 」
 ╚═══════⩽✦✰✦⩾═══════╝
 ║ ☆ 🌟 *𝖡𝖮𝖳 𝖢𝖮𝖭 𝖳𝖤𝖬𝖠𝖳𝖨𝖢𝖠 𝖣𝖤 𝖶𝖠𝖨𝖥𝖴*
 ║ ☆ 🚩 *𝖬𝖮𝖣𝖮*: *𝖯𝖴𝖡𝖫𝖨𝖢𝖮*
 ║ ☆ 📚 *B𝖠𝖨𝖫𝖤𝖸𝖲*: *𝖬𝖴𝖫𝖳𝖨 𝖣𝖤𝖵𝖨𝖢𝖤*
 ║ ☆ 🌐 *𝖢𝖮𝖬𝖠𝖭𝖣𝖮𝖲 𝖤𝖭 𝖳𝖮𝖳𝖠𝖫*: ${totalCommands}
 ║ ☆ ⏱️ *𝖳𝖨𝖤𝖬𝖯𝖮 𝖠𝖢𝖳𝖨𝖵𝖠*: ${uptime}
-║ ☆ 👤 *𝖴𝖲𝖴𝖠𝖱𝖨𝖮𝖲 𝖱𝖤𝖦𝖨𝖲𝖳𝖱𝖠𝖣𝖮𝖲*: ${totalreg}
+║ ☆ 👤 *𝖴𝖲𝖴𝖠𝖱𝖨𝖮𝖲 𝖤𝖭 𝖡𝖠𝖲𝖤 𝖣𝖤 𝖣𝖠𝖳𝖮𝖲*: ${totalreg}
 ║ ☆ 👩‍💻 *𝖢𝖱𝖤𝖠𝖣𝖮𝖱 𝖣𝖤 𝖫𝖠 𝖡𝖮𝖳*: (https://Wa.me/18294868853)
 ╚════════════════════════
 
 
 ╔═══════⩽✦✰✦⩾═══════╗
-     「 𝙄𝙉𝙁𝙊 𝘿𝙀𝙇 𝙐𝙎𝙐𝘼𝙍𝙄𝙊 」
+「 𝙄𝙉𝙁𝙊 𝘿𝙀𝙇 𝙐𝙎𝙐𝘼𝙍𝙄𝙊 」
 ╚═══════⩽✦✰✦⩾═══════╝
 ║ ☆ 🌐 *𝖢𝖫𝖨𝖤𝖭𝖳𝖤*: ${name}
 ║ ☆ 🚀 *𝖤𝖷𝖯𝖤𝖱𝖨𝖤𝖭𝖢𝖨𝖠*: ${exp}
@@ -64,7 +64,7 @@ let handler = async (m, { conn, args }) => {
 > Crea un *sub-bot* de Ruby utilizando *#qr* o *#code*
 
 ╔══⩽✦✰✦⩾══╗
-   「 ${(conn.user.jid == global.conn.user.jid ? '𝘽𝙤𝙩 𝙊𝙛𝙞𝙘𝙞𝙖𝙡' : '𝙎𝙪𝙗𝘽𝙤𝙩')} 」
+「 ${(conn.user.jid == global.conn.user.jid ? '𝘽𝙤𝙩 𝙊𝙛𝙞𝙘𝙞𝙖𝙡' : '𝙎𝙪𝙗𝘽𝙤𝙩')} 」
 ╚══⩽✦✰✦⩾══╝
 
 *L I S T A  -  D E  -  C O M A N D O S*
@@ -378,11 +378,13 @@ let handler = async (m, { conn, args }) => {
 ├┈ ↷𝙋𝘼𝙍𝘼 𝙈𝙊𝘿𝙄𝙁𝙄𝘾𝘼𝙍 𝙏𝙐 𝙋𝙀𝙍𝙁𝙄𝙇
 ├• ✐; ₊˚✦୧︰  .
 ├┈・──・──・﹕₊˚ ✦・୨୧・
-┣ ☬⃝ᩎ⋟᷊᷂᷊᷊᷊᷊᷊᷊᷊᷊᷊᷊᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷊᷊᷂᷂᷂᷂ ☃️ *#𝙧𝙚𝙜 • #𝙫𝙚𝙧𝙞𝙛𝙞𝙘𝙖𝙧 • #𝙧𝙚𝙜𝙞𝙨𝙩𝙚𝙧*
-> ✦ 𝙍𝙚𝙜𝙞𝙨𝙩𝙧𝙖 𝙩𝙪 𝙣𝙤𝙢𝙗𝙧𝙚 𝙮 𝙚𝙙𝙖𝙙 𝙚𝙣 𝙚𝙡 𝙗𝙤𝙩.
-┣ ☬⃝ᩎ⋟᷊᷂᷊᷊᷊᷊᷊᷊᷊᷊᷊᷊᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷊᷊᷂᷂᷂᷂ ☃️ *#𝙪𝙣𝙧𝙚𝙜*
-> ✦ 𝙀𝙡𝙞𝙢𝙞𝙣𝙖 𝙩𝙪 𝙧𝙚𝙜𝙞𝙨𝙩𝙧𝙤 𝙙𝙚𝙡 𝙗𝙤𝙩.
-┣ ☬⃝ᩎ⋟᷊᷂᷊᷊᷊᷊᷊᷊᷊᷊᷊᷊᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷊᷊᷂᷂᷂᷂ ☃️ *#𝙥𝙧𝙤𝙛𝙞𝙡𝙚*
+┣ ☬⃝ᩎ⋟᷊᷂᷊᷊᷊᷊᷊᷊᷊᷊᷊᷊᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷊᷊᷂᷂᷂᷂ ☃️ *#setname*
+> ✦ Establece un nombre personalizado para tu perfil.
+┣ ☬⃝ᩎ⋟᷊᷂᷊᷊᷊᷊᷊᷊᷊᷊᷊᷊᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷊᷊᷂᷂᷂᷂ ☃️ *#setage • #edad*
+> ✦ Agrega o actualiza tu edad en el bot.
+┣ ☬⃝ᩎ⋟᷊᷂᷊᷊᷊᷊᷊᷊᷊᷊᷊᷊᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷊᷊᷂᷂᷂᷂ ☃️ *#unreg • #quitaregistro*
+> ✦ Resetea tu cuenta y elimina tus datos guardados.
+┣ ☬⃝ᩎ⋟᷊᷂᷊᷊᷊᷊᷊᷊᷊᷊᷊᷊᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷊᷊᷂᷂᷂᷂ ☃️ *#profile • #perfil*
 > ✦ 𝙈𝙪𝙚𝙨𝙩𝙧𝙖 𝙩𝙪 𝙥𝙚𝙧𝙛𝙞𝙡 𝙙𝙚 𝙪𝙨𝙪𝙖𝙧𝙞𝙤.
 ┣ ☬⃝ᩎ⋟᷊᷂᷊᷊᷊᷊᷊᷊᷊᷊᷊᷊᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷊᷊᷂᷂᷂᷂ ☃️ *#𝙢𝙖𝙧𝙧𝙮* [𝙢𝙚𝙣𝙨𝙞𝙤𝙣 / 𝙚𝙩𝙞𝙦𝙪𝙚𝙩𝙖𝙧]
 > ✦ 𝙋𝙧𝙤𝙥𝙤́𝙣 𝙢𝙖𝙩𝙧𝙞𝙢𝙤𝙣𝙞𝙤 𝙖 𝙤𝙩𝙧𝙤 𝙪𝙨𝙪𝙖𝙧𝙞𝙤.
@@ -699,31 +701,31 @@ let handler = async (m, { conn, args }) => {
 ┣ ☬⃝ᩎ⋟᷊᷂᷊᷊᷊᷊᷊᷊᷊᷊᷊᷊᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷂᷊᷊᷂᷂᷂᷂ ☃️ *#𝙮𝙪𝙧𝙞 • #𝙩𝙞𝙟𝙚𝙧𝙖𝙨* + <𝙢𝙚𝙣𝙘𝙞𝙤𝙣>
 > ✦ 𝙃𝙖𝙘𝙚𝙧 𝙩𝙞𝙟𝙚𝙧𝙖𝙨.
 ╚▭࣪▬ִ▭࣪▬ִ▭࣪▬ִ▭࣪▬ִ▭࣪▬ִ▭࣪▬▭╝
-  `.trim();
+`.trim();
 
 
-    await conn.reply(m.chat, '*ꪹ͜𓂃⌛͡𝗘𝗻𝘃𝗶𝗮𝗻𝗱𝗼 𝗠𝗲𝗻𝘂 𝗱𝗲 𝗹𝗮 𝗕𝗼𝘁....𓏲੭*', m, { 
-        contextInfo: { 
-            forwardingScore: 2022, 
-            isForwarded: true}
-    });
+await conn.reply(m.chat, '*ꪹ͜𓂃⌛͡𝗘𝗻𝘃𝗶𝗮𝗻𝗱𝗼 𝗠𝗲𝗻𝘂 𝗱𝗲 𝗹𝗮 𝗕𝗼𝘁....𓏲੭*', m, { 
+contextInfo: { 
+forwardingScore: 2022, 
+isForwarded: true}
+});
 
 
-    await m.react('💛');
+await m.react('💛');
 
-    await conn.sendMessage(m.chat, { 
-        video: { url: randomGif },
-        caption: txt,
-        gifPlayback: true,
-        contextInfo: {
-            mentionedJid: [m.sender, userId],
-            isForwarded: true,
-            forwardingScore: 999,
-            forwardedNewsletterMessageInfo: {
-                newsletterJid: '120363335626706839@newsletter',
-                newsletterName: '..⃗. 💌 ⌇ ¡Noticias y más de tu idol favorita! ⊹ ִ ּ',
-                serverMessageId: -1}}
-    }, { quoted: m });
+await conn.sendMessage(m.chat, { 
+video: { url: randomGif },
+caption: txt,
+gifPlayback: true,
+contextInfo: {
+mentionedJid: [m.sender, userId],
+isForwarded: true,
+forwardingScore: 999,
+forwardedNewsletterMessageInfo: {
+newsletterJid: '120363335626706839@newsletter',
+newsletterName: '..⃗. 💌 ⌇ ¡Noticias y más de tu idol favorita! ⊹ ִ ּ',
+serverMessageId: -1}}
+}, { quoted: m });
 
 };
 
@@ -735,19 +737,19 @@ handler.command = ['menuall', 'allmenu', 'allmenù'];
 export default handler;
 
 function clockString(ms) {
-    let seconds = Math.floor((ms / 1000) % 60);
-    let minutes = Math.floor((ms / (1000 * 60)) % 60);
-    let hours = Math.floor((ms / (1000 * 60 * 60)) % 24);
-    return `${hours}h ${minutes}m ${seconds}s`;
+let seconds = Math.floor((ms / 1000) % 60);
+let minutes = Math.floor((ms / (1000 * 60)) % 60);
+let hours = Math.floor((ms / (1000 * 60 * 60)) % 24);
+return `${hours}h ${minutes}m ${seconds}s`;
 
 }
 
 function normalizeMenuSearch(text = '') {
-  return text.normalize('NFKD').toLowerCase();
+return text.normalize('NFKD').toLowerCase();
 }
 
 function commandAliases(command) {
-  if (Array.isArray(command)) return command.filter(cmd => typeof cmd === 'string');
-  if (typeof command === 'string') return [command];
-  return [];
+if (Array.isArray(command)) return command.filter(cmd => typeof cmd === 'string');
+if (typeof command === 'string') return [command];
+return [];
 }

--- a/plugins/main-menuherramientas.js
+++ b/plugins/main-menuherramientas.js
@@ -1,6 +1,6 @@
 
 let handler = async (m, { conn }) => {
-  const texto = `
+const texto = `
 🛠️✨⊹ 𝐂𝐨𝐦𝐚𝐧𝐝𝐨𝐬 𝐝𝐞 𝐡𝐞𝐫𝐫𝐚𝐦𝐢𝐞𝐧𝐭𝐚𝐬 𝐜𝐨𝐧 𝐦𝐮𝐜𝐡𝐚𝐬 𝐟𝐮𝐧𝐜𝐢𝐨𝐧𝐞𝐬 ⚙️
 
 ⢷ ꉹᩙ  ִ ▒🎠ᩬ᷒ᰰ⃞  ˄᪲ *#calcular • #calcular • #cal*  
@@ -17,8 +17,6 @@ let handler = async (m, { conn }) => {
 > ✦ Ver imágenes de una sola vista.
 ⢷ ꉹᩙ  ִ ▒🎡ᩬ᷒ᰰ⃞  ˄᪲ *#whatmusic • #shazam*  
 > ✦ Descubre el nombre de canciones o vídeos.
-⢷ ꉹᩙ  ִ ▒🎠ᩬ᷒ᰰ⃞  ˄᪲ *#spamwa • #spam*  
-> ✦ Envía spam a un usuario.
 ⢷ ꉹᩙ  ִ ▒🎡ᩬ᷒ᰰ⃞  ˄᪲ *#ss • #ssweb*  
 > ✦ Ver el estado de una página web.
 ⢷ ꉹᩙ  ִ ▒🎠ᩬ᷒ᰰ⃞  ˄᪲ *#length • #tamaño*  
@@ -30,26 +28,26 @@ let handler = async (m, { conn }) => {
 ⢷ ꉹᩙ  ִ ▒🎡ᩬ᷒ᰰ⃞  ˄᪲ *#translate • #traducir • #trad*  
 > ✦ Traduce palabras en otros idiomas.
 ╰────︶.︶ ⸙ ͛ ͎ ͛  ︶.︶ ੈ₊˚༅,
-  `.trim();
+`.trim();
 
 
-    await conn.sendMessage(
-    m.chat,
-    {
-      image: { url: 'https://files.catbox.moe/wel1hf.jpeg' },
-      caption: texto,
-      contextInfo: {
-        mentionedJid: [m.sender],
-        isForwarded: true,
-        forwardedNewsletterMessageInfo: {
-        newsletterJid: '120363335626706839@newsletter',
-        newsletterName: '..⃗. 💌 ⌇ ¡Noticias y más de tu idol favorita! ⊹ ִ ּ',
-          serverMessageId: -1,
-        },
-      },
-    },
-    { quoted: fkontak }
-  );
+await conn.sendMessage(
+m.chat,
+{
+image: { url: 'https://files.catbox.moe/wel1hf.jpeg' },
+caption: texto,
+contextInfo: {
+mentionedJid: [m.sender],
+isForwarded: true,
+forwardedNewsletterMessageInfo: {
+newsletterJid: '120363335626706839@newsletter',
+newsletterName: '..⃗. 💌 ⌇ ¡Noticias y más de tu idol favorita! ⊹ ִ ּ',
+serverMessageId: -1,
+},
+},
+},
+{ quoted: fkontak }
+);
 };
 
 handler.command = ['menuherramientas', 'herramientasmenu'];

--- a/plugins/main-menuperfil.js
+++ b/plugins/main-menuperfil.js
@@ -1,13 +1,15 @@
 
 let handler = async (m, { conn }) => {
-  const texto = `
+const texto = `
 🆔✨⊹ 𝐂𝐨𝐦𝐚𝐧𝐝𝐨𝐬 𝐝𝐞 𝐩𝐞𝐫𝐟𝐢𝐥 𝐩𝐚𝐫𝐚 𝐯𝐞𝐫, 𝐜𝐨𝐧𝐟𝐢𝐠𝐮𝐫𝐚𝐫 𝐲 𝐜𝐨𝐦𝐩𝐫𝐨𝐛𝐚𝐫 𝐞𝐬𝐭𝐚𝐝𝐨𝐬 𝐝𝐞 𝐭𝐮 𝐩𝐞𝐫𝐟𝐢𝐥 📇🔍
 
-░ ⃝🌀ᩧ᳕ᬵ *#reg • #verificar • #register*
-> ✦ Registra tu nombre y edad en el bot.
-░ ⃝🌀ᩧ᳕ᬵ *#unreg*
-> ✦ Elimina tu registro del bot.
-░ ⃝🌀ᩧ᳕ᬵ *#profile*
+░ ⃝🌀ᩧ᳕ᬵ *#setname*
+> ✦ Establece un nombre personalizado para tu perfil.
+░ ⃝🌀ᩧ᳕ᬵ *#setage • #edad*
+> ✦ Agrega o actualiza tu edad en el bot.
+░ ⃝🌀ᩧ᳕ᬵ *#unreg • #quitaregistro*
+> ✦ Resetea tu cuenta y elimina tus datos guardados.
+░ ⃝🌀ᩧ᳕ᬵ *#profile • #perfil*
 > ✦ Muestra tu perfil de usuario.
 ░ ⃝🌀ᩧ᳕ᬵ *#marry* [mension / etiquetar]
 > ✦ Propón matrimonio a otro usuario.
@@ -34,26 +36,26 @@ let handler = async (m, { conn }) => {
 ░ ⃝🌀ᩧ᳕ᬵ *#confesiones • #confesar*
 > ✦ Confiesa tus sentimientos a alguien de manera anonima.
 ╰────︶.︶ ⸙ ͛ ͎ ͛  ︶.︶ ੈ₊˚༅
-  `.trim();
+`.trim();
 
 
-    await conn.sendMessage(
-    m.chat,
-    {
-      image: { url: 'https://files.catbox.moe/a2cyzt.jpeg' },
-      caption: texto,
-      contextInfo: {
-        mentionedJid: [m.sender],
-        isForwarded: true,
-        forwardedNewsletterMessageInfo: {
-        newsletterJid: '120363335626706839@newsletter',
-        newsletterName: '..⃗. 💌 ⌇ ¡Noticias y más de tu idol favorita! ⊹ ִ ּ',
-          serverMessageId: -1,
-        },
-      },
-    },
-    { quoted: fkontak }
-  );
+await conn.sendMessage(
+m.chat,
+{
+image: { url: 'https://files.catbox.moe/a2cyzt.jpeg' },
+caption: texto,
+contextInfo: {
+mentionedJid: [m.sender],
+isForwarded: true,
+forwardedNewsletterMessageInfo: {
+newsletterJid: '120363335626706839@newsletter',
+newsletterName: '..⃗. 💌 ⌇ ¡Noticias y más de tu idol favorita! ⊹ ִ ּ',
+serverMessageId: -1,
+},
+},
+},
+{ quoted: fkontak }
+);
 };
 
 handler.command = ['menuperfil', 'perfilmenu'];

--- a/plugins/rg-perfil.js
+++ b/plugins/rg-perfil.js
@@ -1,89 +1,69 @@
-import moment from 'moment-timezone'
-import PhoneNumber from 'awesome-phonenumber'
-import fetch from 'node-fetch'
-import fs from 'fs'
-import path from 'path'
-import { formatJobLine, ensureJobFields } from '../lib/rpg-jobs.js'
-
-const marriagesFile = path.resolve('src/database/casados.json')
-
-function loadMarriages() {
-  try {
-    if (!fs.existsSync(marriagesFile)) return {}
-    return JSON.parse(fs.readFileSync(marriagesFile, 'utf8')) || {}
-  } catch (e) {
-    return {}
-  }
+import fs from'fs'
+import path from'path'
+import{formatJobLine,ensureJobFields}from'../lib/rpg-jobs.js'
+const marriagesFile=path.resolve('src/database/casados.json')
+function loadMarriages(){
+try{
+if(!fs.existsSync(marriagesFile))return{}
+return JSON.parse(fs.readFileSync(marriagesFile,'utf8'))||{}
+}catch(e){
+return{}
 }
-
-function resolvePartnerJid(userId, user) {
-  if (user?.marry) return user.marry
-  const marriages = loadMarriages()
-  if (marriages[userId]?.partner) return marriages[userId].partner
-  return null
 }
-
-let handler = async (m, { conn }) => {
-  let userId
-  if (m.quoted?.sender) {
-    userId = m.quoted.sender
-  } else if (m.mentionedJid?.[0]) {
-    userId = m.mentionedJid[0]
-  } else {
-    userId = m.sender
-  }
-
-  let user = global.db.data.users[userId]
-  if (!user) {
-    return m.reply('⚠️ El usuario no existe en la base de datos.')
-  }
-
-  ensureJobFields(user)
-
-  try {
-    let name
-    try {
-      name = await conn.getName(userId)
-    } catch (e) {
-      name = "𖤐 Sin Nombre 𖤐"
-    }
-
-    let cumpleanos = user.birth || '𖠿 No especificado'
-    let genero = user.genre || '𖠿 No especificado'
-
-    let parejaId = resolvePartnerJid(userId, user)
-    let parejaTag = '✘ Nadie'
-    let mentions = [userId]
-    if (parejaId) {
-      parejaTag = `⚝ @${parejaId.split('@')[0]}`
-      if (/@s\.whatsapp\.net$/.test(parejaId)) mentions.push(parejaId)
-    }
-
-    let description = user.description || '˖ ࣪⊹ Ninguna descripción'
-    let exp = user.exp || 0
-    let nivel = user.level || 0
-    let role = user.role || '✧ Sin rango'
-    let coins = user.coin || 0
-    let bankCoins = user.bank || 0
-    let jobLine = formatJobLine(user)
-    let moneda = m.moneda || 'Coins'
-
-    let perfil
-    try {
-      perfil = await conn.profilePictureUrl(userId, 'image')
-    } catch (e) {
-      perfil = 'https://files.catbox.moe/xr2m6u.jpg'
-    }
-
-    const botName = global.info?.botName || global.botname || "El Propietario"
-
-    let profileText = `
+function resolvePartnerJid(userId,user){
+if(user?.marry)return user.marry
+const marriages=loadMarriages()
+if(marriages[userId]?.partner)return marriages[userId].partner
+return null
+}
+let handler=async(m,{conn,usedPrefix})=>{
+let userId
+if(m.quoted?.sender)userId=m.quoted.sender
+else if(m.mentionedJid?.[0])userId=m.mentionedJid[0]
+else userId=m.sender
+let user=global.db.data.users[userId]
+if(!user)return m.reply('⚠️ El usuario no existe en la base de datos.')
+ensureJobFields(user)
+try{
+let whatsappName
+try{
+whatsappName=await conn.getName(userId)
+}catch(e){
+whatsappName='𖤐 Sin Nombre 𖤐'
+}
+const name=user.customName||user.name||whatsappName
+const cumpleanos=user.birth||'𖠿 No especificado'
+const genero=user.genre||'𖠿 No especificado'
+const age=Number.isFinite(user.age)&&user.age>=0?`${user.age}`:`Desconocida (Usa ${usedPrefix}setage para añadirla)`
+let parejaId=resolvePartnerJid(userId,user)
+let parejaTag='✘ Nadie'
+let mentions=[userId]
+if(parejaId){
+parejaTag=`⚝ @${parejaId.split('@')[0]}`
+if(/@s\.whatsapp\.net$/.test(parejaId))mentions.push(parejaId)
+}
+const description=user.description||'˖ ࣪⊹ Ninguna descripción'
+const exp=user.exp||0
+const nivel=user.level||0
+const role=user.role||'✧ Sin rango'
+const coins=user.coin||0
+const bankCoins=user.bank||0
+const jobLine=formatJobLine(user)
+const moneda=m.moneda||'Coins'
+let perfil
+try{
+perfil=await conn.profilePictureUrl(userId,'image')
+}catch(e){
+perfil='https://files.catbox.moe/xr2m6u.jpg'
+}
+const botName=global.info?.botName||global.botname||'El Propietario'
+const profileText=`
 ╭━━━━「 𝖯𝖤𝖱𝖥𝖨𝖫 𝖣𝖤 𝖴𝖲𝖴𝖠𝖱𝖨𝖮 」━━━━
 │ ⧉ 𖦹 𝖭𝗈𝗆𝖻𝗋𝖾 » ${name}
 │ ⧉ 𖦹 𝖴𝗌𝖾𝗋 » @${userId.split('@')[0]}
 │ ⧉ 𖦹 𝖣𝖾𝗌𝖼𝗋𝗂𝗉𝗍𝗂𝗈𝗇 » ${description}
 ├────────────────────────
-│ ⧉ 𖦹 𝖠𝗀𝖾 » ${user.age || '𖠿 Desconocida'}
+│ ⧉ 𖦹 𝖠𝗀𝖾 » ${age}
 │ ⧉ 𖦹 𝖢𝗎𝗆𝗉𝗅𝖾 » ${cumpleanos}
 │ ⧉ 𖦹 𝖦énero » ${genero}
 │ ⧉ 𖦹 𝖢𝖺𝗌𝖺𝖽𝗈/𝖺 𝖢𝗈𝗇 » ${parejaTag}
@@ -94,29 +74,16 @@ let handler = async (m, { conn }) => {
 ├────────────────────────
 │ ⧉ 𖦹 𝖢𝗈𝗂𝗇𝗌 » ${coins.toLocaleString()} ${moneda}
 │ ⧉ 𖦹 𝖡𝖺𝗇𝗄 » ${bankCoins.toLocaleString()} ${moneda}
-│ ⧉ 𖦹 𝖯𝗋𝖾𝗆𝗂𝗎𝗆 » ${user.premium ? '✔ Activo' : '✘ Inactivo'}
+│ ⧉ 𖦹 𝖯𝗋𝖾𝗆𝗂𝗎𝗆 » ${user.premium?'✔ Activo':'✘ Inactivo'}
 │ ⧉ 𖦹 𝖳𝗋𝖺𝖻𝖺𝗃𝗈 » ${jobLine}
 ╰━━━━「 ⋆｡°✩ ${botName} ⋆｡°✩ 」━━━━
 `.trim()
-
-    await conn.sendMessage(
-      m.chat,
-      {
-        image: { url: perfil },
-        caption: profileText,
-        contextInfo: {
-          mentionedJid: mentions
-        }
-      },
-      { quoted: m }
-    )
-  } catch (e) {
-    await m.reply(`⚠️ Error al mostrar el perfil:\n\n${e.message}`)
-  }
+await conn.sendMessage(m.chat,{image:{url:perfil},caption:profileText,contextInfo:{mentionedJid:mentions}},{quoted:m})
+}catch(e){
+await m.reply(`⚠️ Error al mostrar el perfil:\n\n${e.message}`)
 }
-
-handler.help = ['profile', 'perfil']
-handler.tags = ['rg']
-handler.command = ['profile', 'perfil']
-
+}
+handler.help=['profile','perfil']
+handler.tags=['rg']
+handler.command=['profile','perfil']
 export default handler

--- a/plugins/rg-setage.js
+++ b/plugins/rg-setage.js
@@ -1,40 +1,14 @@
-import { createHash } from 'crypto';
-import fetch from 'node-fetch';
-
-const handler = async (m, { conn, command, usedPrefix, text }) => {
-    const emoji = '✨', emoji2 = '❌';
-    let user = global.db.data.users[m.sender];
-
-    // Validación de entrada vacía
-    if (!text?.trim()) {
-        return conn.reply(m.chat, 
-            `${emoji} Debes ingresar una edad válida.\n> Ejemplo » *${usedPrefix + command} 25*`,
-            m
-        );
-    }
-
-    // Validación de edad
-    const edad = parseInt(text);
-    if (isNaN(edad) || edad < 0 || edad > 120) {
-        return conn.reply(m.chat, 
-            `${emoji2} Por favor ingresa una edad válida entre 0 y 120 años.`,
-            m
-        );
-    }
-
-    // Establecer la edad
-    user.age = edad;
-
-    // Respuesta exitosa
-    return conn.reply(m.chat, 
-        `${emoji} Se ha establecido tu edad como: *${edad}* años!`,
-        m
-    );
-};
-
-// Configuración del comando
-handler.help = ['setage'];
-handler.tags = ['rg'];
-handler.command = ['setage', 'edad'];
-
-export default handler;
+const handler=async(m,{conn,command,usedPrefix,text})=>{
+const emoji='✨'
+const emoji2='❌'
+const user=global.db.data.users[m.sender]||(global.db.data.users[m.sender]={})
+if(!text?.trim())return conn.reply(m.chat,`${emoji} Debes ingresar una edad válida.\n> Ejemplo » *${usedPrefix+command} 25*`,m)
+const edad=Number.parseInt(text.trim(),10)
+if(!Number.isFinite(edad)||edad<0||edad>120)return conn.reply(m.chat,`${emoji2} Por favor ingresa una edad válida entre 0 y 120 años.`,m)
+user.age=edad
+return conn.reply(m.chat,`${emoji} Se ha establecido tu edad como: *${edad}* años.`,m)
+}
+handler.help=['setage','edad']
+handler.tags=['rg']
+handler.command=['setage','edad']
+export default handler

--- a/plugins/rg-setname.js
+++ b/plugins/rg-setname.js
@@ -1,0 +1,15 @@
+const handler=async(m,{conn,command,usedPrefix,text})=>{
+const emoji='✨'
+const emoji2='❌'
+const user=global.db.data.users[m.sender]||(global.db.data.users[m.sender]={})
+const name=text?.trim().replace(/\s+/g,' ')
+if(!name)return conn.reply(m.chat,`${emoji} Escribe el nombre personalizado que quieres usar.\n> Ejemplo » *${usedPrefix+command} Ruby*`,m)
+if(name.length>40)return conn.reply(m.chat,`${emoji2} El nombre personalizado no puede superar 40 caracteres.`,m)
+user.customName=name
+user.name=name
+return conn.reply(m.chat,`${emoji} Tu nombre personalizado ahora es: *${name}*.\n> Si quieres volver a usar tu nombre de WhatsApp, usa *${usedPrefix}unreg si* para resetear tu cuenta.`,m)
+}
+handler.help=['setname']
+handler.tags=['rg']
+handler.command=['setname','setnombre','nombre']
+export default handler

--- a/plugins/rg-unreg.js
+++ b/plugins/rg-unreg.js
@@ -1,40 +1,14 @@
-import { createHash } from 'crypto';
-import fetch from 'node-fetch';
-
-const handler = async (m, { conn, command, usedPrefix, text }) => {
-    const emoji = '✨', emoji2 = '❌';
-    let user = global.db.data.users[m.sender];
-
-    // Validación de usuario no registrado
-    if (!user) {
-        return conn.reply(m.chat, 
-            `${emoji2} No estás registrado, no hay nada que borrar.`,
-            m
-        );
-    }
-
-    // Confirmación antes de borrar
-    const confirmar = text?.toLowerCase();
-    if (confirmar !== 'si') {
-        return conn.reply(m.chat, 
-            `${emoji2} ¿Estás seguro de que quieres reiniciar tu registro? Escribe *${usedPrefix + command} si* para confirmar.`,
-            m
-        );
-    }
-
-    // Borrar el registro
-    delete global.db.data.users[m.sender];
-
-    // Respuesta exitosa
-    return conn.reply(m.chat, 
-        `${emoji} Tu registro ha sido eliminado exitosamente!`,
-        m
-    );
-};
-
-// Configuración del comando
-handler.help = ['unreg'];
-handler.tags = ['rg'];
-handler.command = ['unreg', 'deregistrar'];
-
-export default handler;
+import{userDefault}from'../src/core/defaults.js'
+const handler=async(m,{conn,command,usedPrefix,text})=>{
+const emoji='✨'
+const emoji2='❌'
+const confirmar=text?.trim().toLowerCase()
+if(confirmar!=='si')return conn.reply(m.chat,`${emoji2} ¿Seguro que quieres resetear tu cuenta? Se borrarán tu edad, nombre personalizado, economía, nivel, estadísticas y demás datos de usuario.\n\nEscribe *${usedPrefix+command} si* para confirmar.`,m)
+const whatsappName=String(m.pushName||m.name||conn.getName?.(m.sender)||'').trim()
+global.db.data.users[m.sender]={...userDefault,name:whatsappName,customName:'',registered:false,age:-1,regTime:-1}
+return conn.reply(m.chat,`${emoji} Tu cuenta fue reseteada. Quedaste como usuario nuevo y volveré a usar tu nombre de WhatsApp automáticamente.`,m)
+}
+handler.help=['unreg','quitaregistro']
+handler.tags=['rg']
+handler.command=['unreg','quitaregistro','deregistrar']
+export default handler

--- a/src/core/defaults.js
+++ b/src/core/defaults.js
@@ -1,104 +1,105 @@
 export const userDefault = Object.freeze({
-  exp: 0,
-  coin: 10,
-  joincount: 1,
-  diamond: 3,
-  lastadventure: 0,
-  health: 100,
-  lastclaim: 0,
-  lastcofre: 0,
-  lastdiamantes: 0,
-  lastcode: 0,
-  lastduel: 0,
-  lastpago: 0,
-  lastmining: 0,
-  lastcodereg: 0,
-  muto: false,
-  premium: false,
-  premiumTime: 0,
-  registered: false,
-  genre: '',
-  birth: '',
-  marry: '',
-  description: '',
-  packstickers: null,
-  name: '',
-  age: -1,
-  regTime: -1,
-  afk: -1,
-  afkReason: '',
-  role: 'Nuv',
-  banned: false,
-  useDocument: false,
-  level: 0,
-  bank: 0,
-  warn: 0,
-  crime: 0,
-  Subs: 0,
+exp: 0,
+coin: 10,
+joincount: 1,
+diamond: 3,
+lastadventure: 0,
+health: 100,
+lastclaim: 0,
+lastcofre: 0,
+lastdiamantes: 0,
+lastcode: 0,
+lastduel: 0,
+lastpago: 0,
+lastmining: 0,
+lastcodereg: 0,
+muto: false,
+premium: false,
+premiumTime: 0,
+registered: false,
+genre: '',
+birth: '',
+marry: '',
+description: '',
+packstickers: null,
+name: '',
+customName: '',
+age: -1,
+regTime: -1,
+afk: -1,
+afkReason: '',
+role: 'Nuv',
+banned: false,
+useDocument: false,
+level: 0,
+bank: 0,
+warn: 0,
+crime: 0,
+Subs: 0,
 })
 
 export const chatDefault = Object.freeze({
-  welcome: true,
-  isBanned: false,
-  autolevelup: false,
-  delete: false,
-  detect: true,
-  antiBot: false,
-  antiBot2: false,
-  modoadmin: false,
-  antiLink: true,
-  antiArabe: false,
-  reaction: false,
-  nsw: false,
-  expired: 0,
-  welcomeText: null,
-  byeText: null,
-  audios: false,
-  botPrimario: null,
-  primaryBot: null,
-  bannedBots: [],
-  antiImg: false,
-  nsfw: false,
+welcome: true,
+isBanned: false,
+autolevelup: false,
+delete: false,
+detect: true,
+antiBot: false,
+antiBot2: false,
+modoadmin: false,
+antiLink: true,
+antiArabe: false,
+reaction: false,
+nsw: false,
+expired: 0,
+welcomeText: null,
+byeText: null,
+audios: false,
+botPrimario: null,
+primaryBot: null,
+bannedBots: [],
+antiImg: false,
+nsfw: false,
 })
 
 export const settingsDefault = Object.freeze({
-  self: false,
-  restrict: true,
-  jadibotmd: true,
-  antiPrivate: false,
-  moneda: 'Coins',
-  autoread: false,
-  status: 0,
+self: false,
+restrict: true,
+jadibotmd: true,
+antiPrivate: false,
+moneda: 'Coins',
+autoread: false,
+status: 0,
 })
 
 const isNumber = (value) => typeof value === 'number' && Number.isFinite(value)
 
 export function ensureRecord(container, key, defaults, patches = {}) {
-  if (!container || !key) return {}
-  if (!container[key] || typeof container[key] !== 'object') container[key] = {}
-  const record = container[key]
-  for (const [field, defaultValue] of Object.entries(defaults)) {
-    const value = field in patches ? patches[field] : defaultValue
-    if (value === null) continue
-    if (typeof record[field] === 'undefined') {
-      record[field] = value
-    } else if (typeof value === 'number' && !isNumber(record[field])) {
-      record[field] = value
-    } else if (Array.isArray(value) && !Array.isArray(record[field])) {
-      record[field] = [...value]
-    }
-  }
-  return record
+if (!container || !key) return {}
+if (!container[key] || typeof container[key] !== 'object') container[key] = {}
+const record = container[key]
+for (const [field, defaultValue] of Object.entries(defaults)) {
+const value = field in patches ? patches[field] : defaultValue
+if (value === null) continue
+if (typeof record[field] === 'undefined') {
+record[field] = value
+} else if (typeof value === 'number' && !isNumber(record[field])) {
+record[field] = value
+} else if (Array.isArray(value) && !Array.isArray(record[field])) {
+record[field] = [...value]
+}
+}
+return record
 }
 
 export function ensureDatabaseShape(db = global.db) {
-  if (!db.data || typeof db.data !== 'object') db.data = {}
-  db.data.users ||= {}
-  db.data.chats ||= {}
-  db.data.stats ||= {}
-  db.data.msgs ||= {}
-  db.data.sticker ||= {}
-  db.data.settings ||= {}
-  db.data.sessions ||= {}
-  return db.data
+if (!db.data || typeof db.data !== 'object') db.data = {}
+db.data.users ||= {}
+db.data.chats ||= {}
+db.data.stats ||= {}
+db.data.msgs ||= {}
+db.data.sticker ||= {}
+db.data.settings ||= {}
+db.data.sessions ||= {}
+return db.data
 }

--- a/src/core/handler-utils.js
+++ b/src/core/handler-utils.js
@@ -9,162 +9,164 @@ export const GROUP_METADATA_MAX = 2000
 export const isNumber = (x) => typeof x === 'number' && Number.isFinite(x)
 
 export function normalizeParticipant(participant = {}) {
-  return {
-    ...participant,
-    id: participant?.jid || participant?.id,
-    jid: participant?.jid || participant?.id,
-    lid: participant?.lid,
-    admin: participant?.admin || participant?.isAdmin || participant?.role,
-  }
+return {
+...participant,
+id: participant?.jid || participant?.id,
+jid: participant?.jid || participant?.id,
+lid: participant?.lid,
+admin: participant?.admin || participant?.isAdmin || participant?.role,
+}
 }
 
 export async function getCachedGroupMetadata(conn, chatId) {
-  if (!conn || !chatId) return {}
-  conn.__groupMetadataCache ||= new TTLCache(GROUP_METADATA_TTL, GROUP_METADATA_MAX)
-  const cached = conn.__groupMetadataCache.get(chatId)
-  if (cached) return cached
-  const metadata = await conn.groupMetadata?.(chatId).catch(() => null) || {}
-  if (Array.isArray(metadata?.participants)) metadata.participants = metadata.participants.map(normalizeParticipant)
-  conn.__groupMetadataCache.set(chatId, metadata)
-  return metadata
+if (!conn || !chatId) return {}
+conn.__groupMetadataCache ||= new TTLCache(GROUP_METADATA_TTL, GROUP_METADATA_MAX)
+const cached = conn.__groupMetadataCache.get(chatId)
+if (cached) return cached
+const metadata = await conn.groupMetadata?.(chatId).catch(() => null) || {}
+if (Array.isArray(metadata?.participants)) metadata.participants = metadata.participants.map(normalizeParticipant)
+conn.__groupMetadataCache.set(chatId, metadata)
+return metadata
 }
 
 export function createParticipantIndex(participants = []) {
-  const byLid = new Map()
-  for (const p of participants) if (p?.lid) byLid.set(p.lid, p)
-  return byLid
+const byLid = new Map()
+for (const p of participants) if (p?.lid) byLid.set(p.lid, p)
+return byLid
 }
 
 export function normalizeLidReferences(m, sender, participantsByLid) {
-  let normalizedSender = sender
-  if (!m?.isGroup || !participantsByLid) return normalizedSender
-  if (normalizedSender?.endsWith?.('@lid')) {
-    const pInfo = participantsByLid.get(normalizedSender)
-    if (pInfo?.jid) {
-      normalizedSender = pInfo.jid
-      if (m.key) m.key.participant = pInfo.jid
-      try { m.sender = pInfo.jid } catch {}
-    }
-  }
-  if (m.quoted?.sender?.endsWith?.('@lid')) {
-    const pInfo = participantsByLid.get(m.quoted.sender)
-    if (pInfo?.jid) {
-      if (m.quoted.key) m.quoted.key.participant = pInfo.jid
-      try { m.quoted.sender = pInfo.jid } catch {}
-    }
-  }
-  if (Array.isArray(m.mentionedJid) && m.mentionedJid.length > 0) {
-    const normalizedMentions = m.mentionedJid.map((jid) => {
-      if (jid?.endsWith?.('@lid')) return participantsByLid.get(jid)?.jid || jid
-      return jid
-    })
-    try { m.mentionedJid = normalizedMentions } catch {}
-  }
-  return normalizedSender
+let normalizedSender = sender
+if (!m?.isGroup || !participantsByLid) return normalizedSender
+if (normalizedSender?.endsWith?.('@lid')) {
+const pInfo = participantsByLid.get(normalizedSender)
+if (pInfo?.jid) {
+normalizedSender = pInfo.jid
+if (m.key) m.key.participant = pInfo.jid
+try { m.sender = pInfo.jid } catch {}
+}
+}
+if (m.quoted?.sender?.endsWith?.('@lid')) {
+const pInfo = participantsByLid.get(m.quoted.sender)
+if (pInfo?.jid) {
+if (m.quoted.key) m.quoted.key.participant = pInfo.jid
+try { m.quoted.sender = pInfo.jid } catch {}
+}
+}
+if (Array.isArray(m.mentionedJid) && m.mentionedJid.length > 0) {
+const normalizedMentions = m.mentionedJid.map((jid) => {
+if (jid?.endsWith?.('@lid')) return participantsByLid.get(jid)?.jid || jid
+return jid
+})
+try { m.mentionedJid = normalizedMentions } catch {}
+}
+return normalizedSender
 }
 
 export function hydrateDatabaseForMessage(conn, m, sender) {
-  const data = ensureDatabaseShape(global.db)
-  const user = ensureRecord(data.users, sender, userDefault, { name: m?.name || userDefault.name })
-  const chat = m?.chat ? ensureRecord(data.chats, m.chat, chatDefault) : {}
-  const botJid = conn?.user?.jid || conn?.session?.id || 'primary'
-  const settings = ensureRecord(data.settings, botJid, settingsDefault)
-  return { data, user, chat, settings }
+const data = ensureDatabaseShape(global.db)
+const whatsappName = String(m?.pushName || m?.name || conn?.getName?.(sender) || '').trim()
+const user = ensureRecord(data.users, sender, userDefault, { name: whatsappName || userDefault.name })
+if (whatsappName && !user.customName && user.name !== whatsappName) user.name = whatsappName
+const chat = m?.chat ? ensureRecord(data.chats, m.chat, chatDefault) : {}
+const botJid = conn?.user?.jid || conn?.session?.id || 'primary'
+const settings = ensureRecord(data.settings, botJid, settingsDefault)
+return { data, user, chat, settings }
 }
 
 export function normalizeAdmin(participant) {
-  const admin = participant?.admin ?? false
-  if (admin === true || admin === 'admin') return 'admin'
-  if (['creator', 'superadmin', 'owner'].includes(admin)) return 'superadmin'
-  return false
+const admin = participant?.admin ?? false
+if (admin === true || admin === 'admin') return 'admin'
+if (['creator', 'superadmin', 'owner'].includes(admin)) return 'superadmin'
+return false
 }
 
 export function buildPermissionContext(conn, m, sender, participants = []) {
-  const decode = (jid) => conn?.decodeJid ? conn.decodeJid(jid) : jid
-  const userGroup = (m?.isGroup ? participants.find((u) => decode(u?.jid) === sender) : {}) || {}
-  const botGroup = (m?.isGroup ? participants.find((u) => decode(u?.jid) === conn?.user?.jid) : {}) || {}
-  const isRAdmin = normalizeAdmin(userGroup) === 'superadmin'
-  const isAdmin = isRAdmin || normalizeAdmin(userGroup) === 'admin'
-  const isBotAdmin = ['admin', 'superadmin'].includes(normalizeAdmin(botGroup))
-  const senderNum = String(sender || '').split('@')[0]
-  const isROwner = (global.owner || []).map(([number]) => number).includes(senderNum)
-  const isOwner = isROwner
-  const isMods = isOwner || (global.mods || []).map((v) => v.replace(/[^0-9]/g, '')).includes(senderNum)
-  const isPrems = isROwner || (global.prems || []).map((v) => v.replace(/[^0-9]/g, '')).includes(senderNum) || global.db?.data?.users?.[sender]?.premium === true
-  return { userGroup, botGroup, isRAdmin, isAdmin, isBotAdmin, isROwner, isOwner, isMods, isPrems }
+const decode = (jid) => conn?.decodeJid ? conn.decodeJid(jid) : jid
+const userGroup = (m?.isGroup ? participants.find((u) => decode(u?.jid) === sender) : {}) || {}
+const botGroup = (m?.isGroup ? participants.find((u) => decode(u?.jid) === conn?.user?.jid) : {}) || {}
+const isRAdmin = normalizeAdmin(userGroup) === 'superadmin'
+const isAdmin = isRAdmin || normalizeAdmin(userGroup) === 'admin'
+const isBotAdmin = ['admin', 'superadmin'].includes(normalizeAdmin(botGroup))
+const senderNum = String(sender || '').split('@')[0]
+const isROwner = (global.owner || []).map(([number]) => number).includes(senderNum)
+const isOwner = isROwner
+const isMods = isOwner || (global.mods || []).map((v) => v.replace(/[^0-9]/g, '')).includes(senderNum)
+const isPrems = isROwner || (global.prems || []).map((v) => v.replace(/[^0-9]/g, '')).includes(senderNum) || global.db?.data?.users?.[sender]?.premium === true
+return { userGroup, botGroup, isRAdmin, isAdmin, isBotAdmin, isROwner, isOwner, isMods, isPrems }
 }
 
 export function runMaintenance(conn) {
-  conn.msgqueque ||= []
-  conn.uptime ||= Date.now()
-  conn.__maintenanceAt ||= 0
-  if (Date.now() - conn.__maintenanceAt <= 60_000) return
-  conn.__maintenanceAt = Date.now()
-  conn.__groupMetadataCache?.clearExpired?.()
-  if (conn.__commandTesterCache?.size > 3000) conn.__commandTesterCache.clear()
-  if (conn.__prefixMatcherCache?.size > 2000) conn.__prefixMatcherCache.clear()
+conn.msgqueque ||= []
+conn.uptime ||= Date.now()
+conn.__maintenanceAt ||= 0
+if (Date.now() - conn.__maintenanceAt <= 60_000) return
+conn.__maintenanceAt = Date.now()
+conn.__groupMetadataCache?.clearExpired?.()
+if (conn.__commandTesterCache?.size > 3000) conn.__commandTesterCache.clear()
+if (conn.__prefixMatcherCache?.size > 2000) conn.__prefixMatcherCache.clear()
 }
 
 
 export function commandMatches(pluginCommand, command = '') {
-  if (!pluginCommand) return false
-  if (pluginCommand instanceof RegExp) {
-    pluginCommand.lastIndex = 0
-    return pluginCommand.test(command)
-  }
-  if (Array.isArray(pluginCommand)) {
-    return pluginCommand.some((cmd) => {
-      if (typeof cmd === 'string') return cmd === command
-      if (cmd instanceof RegExp) {
-        cmd.lastIndex = 0
-        return cmd.test(command)
-      }
-      return false
-    })
-  }
-  if (typeof pluginCommand === 'string') return pluginCommand === command
-  if (typeof pluginCommand === 'function') return pluginCommand(command)
-  return false
+if (!pluginCommand) return false
+if (pluginCommand instanceof RegExp) {
+pluginCommand.lastIndex = 0
+return pluginCommand.test(command)
+}
+if (Array.isArray(pluginCommand)) {
+return pluginCommand.some((cmd) => {
+if (typeof cmd === 'string') return cmd === command
+if (cmd instanceof RegExp) {
+cmd.lastIndex = 0
+return cmd.test(command)
+}
+return false
+})
+}
+if (typeof pluginCommand === 'string') return pluginCommand === command
+if (typeof pluginCommand === 'function') return pluginCommand(command)
+return false
 }
 
 export function getCommandTester(conn, pluginName, pluginCommand) {
-  conn.__commandTesterCache ||= new Map()
-  const cache = conn.__commandTesterCache
-  const cacheKey = `${pluginName}:${typeof pluginCommand}`
-  let tester = cache.get(cacheKey)
-  if (tester?.__source === pluginCommand) return tester
-  tester = (command) => commandMatches(pluginCommand, command)
-  tester.__source = pluginCommand
-  cache.set(cacheKey, tester)
-  return tester
+conn.__commandTesterCache ||= new Map()
+const cache = conn.__commandTesterCache
+const cacheKey = `${pluginName}:${typeof pluginCommand}`
+let tester = cache.get(cacheKey)
+if (tester?.__source === pluginCommand) return tester
+tester = (command) => commandMatches(pluginCommand, command)
+tester.__source = pluginCommand
+cache.set(cacheKey, tester)
+return tester
 }
 
 export function getPrefixMatch(conn, plugin, text) {
-  const str2Regex = (str) => str.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
-  const prefixCache = getPrefixMatcherCache(conn)
-  const _prefix = plugin.customPrefix || conn.prefix || global.prefix
-  return (_prefix instanceof RegExp ? [[_prefix.exec(text), _prefix]]
-    : Array.isArray(_prefix) ? _prefix.map((p) => {
-      const cacheKey = p instanceof RegExp ? `re:${p.source}:${p.flags}` : `str:${p}`
-      let re = prefixCache.get(cacheKey)
-      if (!re) {
-        re = p instanceof RegExp ? p : new RegExp(str2Regex(p))
-        prefixCache.set(cacheKey, re)
-      }
-      return [re.exec(text), re]
-    })
-      : typeof _prefix === 'string' ? (() => {
-        const cacheKey = `str:${_prefix}`
-        let re = prefixCache.get(cacheKey)
-        if (!re) {
-          re = new RegExp(str2Regex(_prefix))
-          prefixCache.set(cacheKey, re)
-        }
-        return [[re.exec(text), re]]
-      })() : [[[], new RegExp()]])
-    .find((p) => p[1])
+const str2Regex = (str) => str.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
+const prefixCache = getPrefixMatcherCache(conn)
+const _prefix = plugin.customPrefix || conn.prefix || global.prefix
+return (_prefix instanceof RegExp ? [[_prefix.exec(text), _prefix]]
+: Array.isArray(_prefix) ? _prefix.map((p) => {
+const cacheKey = p instanceof RegExp ? `re:${p.source}:${p.flags}` : `str:${p}`
+let re = prefixCache.get(cacheKey)
+if (!re) {
+re = p instanceof RegExp ? p : new RegExp(str2Regex(p))
+prefixCache.set(cacheKey, re)
+}
+return [re.exec(text), re]
+})
+: typeof _prefix === 'string' ? (() => {
+const cacheKey = `str:${_prefix}`
+let re = prefixCache.get(cacheKey)
+if (!re) {
+re = new RegExp(str2Regex(_prefix))
+prefixCache.set(cacheKey, re)
+}
+return [[re.exec(text), re]]
+})() : [[[], new RegExp()]])
+.find((p) => p[1])
 }
 
 export function getPluginDirectory() {
-  return join(fileURLToPath(new URL('../..', import.meta.url)), 'plugins')
+return join(fileURLToPath(new URL('../..', import.meta.url)), 'plugins')
 }


### PR DESCRIPTION
### Motivation
- Simplificar la experiencia de usuario eliminando la obligación de usar un registro (antes `#reg`) y permitir que el bot use el nombre de WhatsApp por defecto salvo cuando el usuario haya establecido un `customName`.
- Añadir comandos prácticos para gestionar perfil (`#setname`, `#setage`, `#unreg` como reseteo) y ofrecer la funcionalidad faltante para ver contenido "view-once" (`#ver`).

### Description
- Quité la verificación que bloqueaba plugins por falta de registro en el flujo de manejo de comandos y actualicé la hidratación de la DB para inicializar/actualizar el nombre del usuario con el nombre de WhatsApp salvo si existe `customName` (`src/core/handler-utils.js`, `handler.js`).
- Agregué `customName` al objeto por defecto de usuario y ajustes de `ensureRecord` para mantener la forma de la DB (`src/core/defaults.js`).
- Convirti `#unreg` en un reseteo de cuenta que restaura los valores por defecto (borra edad, `customName`, estadísticas, etc.) y preserva el nombre de WhatsApp como valor inicial (`plugins/rg-unreg.js`).
- Implementé `#setname` para establecer un nombre personalizado (`plugins/rg-setname.js`) y mejoré `#setage` para validar y guardar la edad del usuario (`plugins/rg-setage.js`).
- Actualicé `#perfil` / `#profile` para mostrar `customName` o el nombre de WhatsApp y para mostrar la edad como "Desconocida (Usa #setage para añadirla)" cuando no esté establecida (`plugins/rg-perfil.js`).
- Creé `plugins/cmd-ver.js` para reenviar imágenes/videos respondidos que originalmente eran view-once y así hacerlos visibles normalmente (`#ver`, `#readviewonce`, `#read`).
- Limpié menús de texto eliminando la referencia `#spamwa`, quitando menciones a registro obligatorio y añadiendo `#setname` y `#setage` en los menús relevantes (`plugins/main-menu.js`, `plugins/main-menuperfil.js`, `plugins/main-menuherramientas.js`).

### Testing
- Ejecuté `npm test` y la comprobación de sintaxis con `node --check` sobre `handler.js` y ficheros modificados; los chequeos automáticos concluyeron correctamente (sin errores de sintaxis).
- Ejecuté una comprobación de todos los plugins con `find plugins src/core -name '*.js' -print0 | xargs -0 -n 1 node --check` y no se reportaron errores de parsing.
- Se realizaron pruebas de lint/syntax de forma puntual con `node --check` sobre los nuevos/actualizados archivos (`plugins/rg-setage.js`, `plugins/rg-setname.js`, `plugins/rg-unreg.js`, `plugins/rg-perfil.js`, `plugins/cmd-ver.js`, `plugins/main-menu*.js`) y todas pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2433346024832186133c13701fbe5a)